### PR TITLE
feat: new /searh/withcontent endpoint

### DIFF
--- a/src/main/java/com/contented/contented/contentlet/ContentletService.java
+++ b/src/main/java/com/contented/contented/contentlet/ContentletService.java
@@ -3,9 +3,11 @@ package com.contented.contented.contentlet;
 import com.contented.contented.contentlet.elasticsearch.ContentletIndexer;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import javax.swing.text.AbstractDocument;
+import java.util.List;
 
 @Log4j2
 @Service
@@ -56,6 +58,11 @@ public class ContentletService {
                         log.debug("contentlet: {} not found", id);
                     }
                 });
+    }
+
+    public Flux<ContentletEntity> findByIds(List<String> ids) {
+        log.debug("Finding {} contentlets", ids.size());
+        return contentletRepository.findAllById(ids);
     }
 
     record ResultPair(ContentletEntity contentletEntity, boolean isNew) {

--- a/src/main/java/com/contented/contented/contentlet/elasticsearch/SearchController.java
+++ b/src/main/java/com/contented/contented/contentlet/elasticsearch/SearchController.java
@@ -1,10 +1,59 @@
 package com.contented.contented.contentlet.elasticsearch;
 
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import com.contented.contented.contentlet.ContentletService;
+import org.springframework.data.elasticsearch.client.elc.EntityAsMap;
+import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+import java.io.ByteArrayInputStream;
+import java.util.List;
 
 @RestController
 @RequestMapping(SearchController.SEARCH_PATH)
 public class SearchController {
     public static final String SEARCH_PATH = "search";
+
+    private final ReactiveElasticsearchClient reactiveElasticsearchClient;
+
+    private final IndexCoordinates indexCoordinates;
+
+    private final ContentletService contentletService;
+
+
+    public SearchController(ReactiveElasticsearchClient reactiveElasticsearchClient, IndexCoordinates indexCoordinates, ContentletService contentletService) {
+        this.reactiveElasticsearchClient = reactiveElasticsearchClient;
+        this.indexCoordinates = indexCoordinates;
+        this.contentletService = contentletService;
+    }
+
+    @PostMapping("/withcontent")
+    public Mono<SearchResultsWithContent<EntityAsMap>> searchWithContent(@RequestBody String searchRequestJSON) {
+
+        SearchRequest request = builderFromJSON(searchRequestJSON)
+            .index(indexCoordinates.getIndexName()).build();
+
+        return reactiveElasticsearchClient.search(request, EntityAsMap.class)
+            .flatMap(response -> {
+                List<String> extractedIds = response.hits().hits().stream()
+                    .map(hit -> (String) hit.source().get("id"))
+                    .toList();
+
+                return contentletService.findByIds(extractedIds)
+                    .collectList()
+                    .map(contentlets -> new SearchResultsWithContent<>(response, contentlets));
+
+            });
+    }
+
+    private SearchRequest.Builder builderFromJSON(String searchRequestJSON) {
+        SearchRequest.Builder builder = new SearchRequest.Builder();
+        builder.withJson(new ByteArrayInputStream(searchRequestJSON.getBytes()));
+        return builder;
+    }
 }

--- a/src/main/java/com/contented/contented/contentlet/elasticsearch/SearchResultsWithContent.java
+++ b/src/main/java/com/contented/contented/contentlet/elasticsearch/SearchResultsWithContent.java
@@ -1,0 +1,9 @@
+package com.contented.contented.contentlet.elasticsearch;
+
+import co.elastic.clients.elasticsearch.core.search.ResponseBody;
+import com.contented.contented.contentlet.ContentletEntity;
+
+import java.util.List;
+
+public record SearchResultsWithContent<T>(ResponseBody<T> esResponse, List<ContentletEntity> contentlets) {
+}

--- a/src/test/java/com/contented/contented/contentlet/AbstractContentletControllerTests.java
+++ b/src/test/java/com/contented/contented/contentlet/AbstractContentletControllerTests.java
@@ -17,8 +17,12 @@ public abstract class AbstractContentletControllerTests {
 
     @BeforeAll()
     void beforeAll() {
+        contentletEndpointClient = createContentletsEndpointClient(port);
+    }
+
+    public static WebTestClient createContentletsEndpointClient(int port) {
         var baseURL = String.format("http://localhost:%s/%s", port, ContentletController.CONTENTLETS_PATH);
-        contentletEndpointClient = WebTestClient.bindToServer().baseUrl(baseURL).build();
+        return WebTestClient.bindToServer().baseUrl(baseURL).build();
     }
 
 }

--- a/src/test/java/com/contented/contented/contentlet/elasticsearch/ElasticSearchDiscoveryTests.java
+++ b/src/test/java/com/contented/contented/contentlet/elasticsearch/ElasticSearchDiscoveryTests.java
@@ -284,17 +284,14 @@ public class ElasticSearchDiscoveryTests {
             void the_document_should_be_searchable_by_json_query_on_the_id_field() {
 
                 // This is what would be inside the "query" object.
-                var query = new StringQuery("""
+                var queryTemplate = """
                     {
-                        "bool": {
-                            "must": {
-                                "exists": {
-                                    "field": "id"
-                                }
-                            }
+                        "term": {
+                            "id": "%s"
                         }
                     }
-                    """);
+                    """;
+                var query = new StringQuery(String.format(queryTemplate,toSave.id()));
                 reactiveElasticsearchOperations.search(query, ESDocument.class, IndexCoordinates.of(INDEX_NAME3))
                     .collectList()
                     .as(StepVerifier::create)
@@ -310,19 +307,16 @@ public class ElasticSearchDiscoveryTests {
 
                 // This is the "full" query like we would use if we were going
                 // directly to the elasticsearch /_search endpoint
-                var queryString = """
+                var queryStringTemplate = """
                     {
                         "query": {
-                            "bool": {
-                                "must": {
-                                    "exists": {
-                                        "field": "id"
-                                    }
-                                }
+                            "term": {
+                                "id": "%s"
                             }
                         }
                     }
                     """;
+                var queryString = String.format(queryStringTemplate, toSave.id());
                 SearchRequest.Builder builder = new SearchRequest.Builder();
                 builder.withJson(new ByteArrayInputStream(queryString.getBytes()));
                 SearchRequest searchRequest = builder.index(INDEX_NAME3).build();

--- a/src/test/java/com/contented/contented/contentlet/elasticsearch/SearchControllerTests.java
+++ b/src/test/java/com/contented/contented/contentlet/elasticsearch/SearchControllerTests.java
@@ -1,10 +1,17 @@
 package com.contented.contented.contentlet.elasticsearch;
 
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.ResponseBody;
+import com.contented.contented.contentlet.AbstractContentletControllerTests;
+import com.contented.contented.contentlet.ContentletEntity;
 import com.contented.contented.contentlet.testutils.NestedPerClass;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.jupiter.api.*;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.data.elasticsearch.client.elc.EntityAsMap;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
@@ -12,6 +19,9 @@ import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.List;
 
 import static com.contented.contented.contentlet.testutils.ElasticSearchContainerUtils.*;
 import static com.contented.contented.contentlet.testutils.MongoDBContainerUtils.*;
@@ -40,42 +50,74 @@ public class SearchControllerTests {
 
     WebTestClient searchEndpointClient;
 
+    WebTestClient contentletEndpointClient;
+
     @BeforeAll
     void beforeAll() {
         var baseURL = String.format("http://localhost:%s/%s", port, SearchController.SEARCH_PATH);
         searchEndpointClient = WebTestClient.bindToServer().baseUrl(baseURL).build();
+
+        contentletEndpointClient = AbstractContentletControllerTests.createContentletsEndpointClient(port);
     }
 
-    @Disabled
     @NestedPerClass
-    @DisplayName("Given content that is indexed by its identifier was saved")
-    class GivenContentIndexedByIdentifier {
-
-
+    @DisplayName("POST /withcontent endpoint")
+    class WithContentEndpoint {
         @NestedPerClass
-        @DisplayName("When a search is performed by its identifier")
-        class WhenSearchByIdentifier {
+        @DisplayName("Given content that is indexed by its identifier was saved")
+        class GivenContentIndexedByIdentifier {
+
+            record SomeContent(String id, String someOtherField){};
+
+            final SomeContent savedContent = new SomeContent("123XYZ", "Some field value");
 
             @BeforeAll
-            void when() {
+            void given() {
 
-
+                // Could use rest endpoint, or could go directly to service
+                contentletEndpointClient.put().bodyValue(savedContent)
+                    .exchange().expectStatus().is2xxSuccessful();
             }
 
-            @Test
-            @DisplayName("it should return a 200 OK status code")
-            void it_should_return_a_200_OK_status_code() {
 
-            }
+            @NestedPerClass
+            @DisplayName("When a query by its identifier is given")
+            class WhenSearchByIdentifier {
 
-            @Ignore
-            @Test
-            @DisplayName("it should return the contentlet")
-            void it_should_return_the_contentlet() {
+                String queryForContentTemplate = """
+                {
+                    "query": {
+                        "term": {
+                            "id": "%s"
+                        }
+                    }
+                }
+                """;
+
+                WebTestClient.ResponseSpec response;
+
+                @BeforeAll
+                void when() {
+                    var queryString = String.format(queryForContentTemplate, savedContent.id());
+                    response = searchEndpointClient.post().uri("/withcontent").bodyValue(queryString).exchange();
+                }
+
+                @Test
+                @DisplayName("it should return a 200 OK status code")
+                void it_should_return_a_200_OK_status_code() {
+                    response.expectStatus().isOk();
+                }
+
+                @Test
+                @DisplayName("it should return a response with ElasticSearch 'esResponse' field and 'contentlets' field")
+                void it_should_return_the_contentlet() {
+                    var bodySpec = response.expectBody();
+                    bodySpec.jsonPath("$.esResponse").exists();
+                    bodySpec.jsonPath("$.contentlets").exists();
+                }
 
             }
 
         }
-
     }
 }


### PR DESCRIPTION
This endpoint will perform whatever search is given to it, find the corresponding entities in the database and return a result containing both the ElasticSearch response and the entities