### PR TITLE
Switch from Webflux and Reactor to Traditional Spring MVC

### DIFF
--- a/src/main/java/com/contented/contented/ContentedApplication.java
+++ b/src/main/java/com/contented/contented/ContentedApplication.java
@@ -7,7 +7,6 @@ import org.springframework.boot.actuate.autoconfigure.metrics.LogbackMetricsAuto
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.sql.init.SqlInitializationAutoConfiguration;
 import org.springframework.context.annotation.Bean;
-import reactor.core.publisher.Hooks;
 
 import java.time.Clock;
 
@@ -16,7 +15,6 @@ import java.time.Clock;
 public class ContentedApplication {
 
 	public static void main(String[] args) {
-        Hooks.enableAutomaticContextPropagation();
         SpringApplication.run(ContentedApplication.class, args);
 	}
 

--- a/src/main/java/com/contented/contented/contentlet/ContentletController.java
+++ b/src/main/java/com/contented/contented/contentlet/ContentletController.java
@@ -5,8 +5,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
+
+import java.util.List;
 
 @RestController
 @RequestMapping(ContentletController.CONTENTLETS_PATH)
@@ -25,33 +25,32 @@ public class ContentletController {
     }
 
     @GetMapping("/all")
-    Flux<ContentletEntity> getAll() {
+    List<ContentletEntity> getAll() {
         // TODO: Replace this with a paginated version in the future
         return contentletRepository.findAll();
     }
 
     @GetMapping("/{id}")
-    Mono<ResponseEntity<ContentletEntity>> findById(@PathVariable String id) {
-        return contentletService.findById(id)
-                .map(contentletEntity -> ResponseEntity.ok(contentletEntity))
-                .defaultIfEmpty(ResponseEntity.notFound().build());
+    ResponseEntity<ContentletEntity> findById(@PathVariable String id) {
+        ContentletEntity contentletEntity = contentletService.findById(id);
+        if (contentletEntity != null) {
+            return ResponseEntity.ok(contentletEntity);
+        } else {
+            return ResponseEntity.notFound().build();
+        }
     }
 
     @PutMapping
-    Mono<ResponseEntity<ContentletEntity>> putContentlet(@RequestBody ContentletDTO contentletDTO) {
+    ResponseEntity<ContentletEntity> putContentlet(@RequestBody ContentletDTO contentletDTO) {
         ContentletEntity toSave = new ContentletEntity(contentletDTO.getId(), contentletDTO.get());
 
-        return contentletService.save(toSave)
-                .map(resultPair -> {
-                    var statusCode = resultPair.isNew() ? HttpStatus.CREATED : HttpStatus.OK;
-                    return ResponseEntity.status(statusCode)
-                            .body(resultPair.contentletEntity());
-                });
+        ContentletService.ResultPair resultPair = contentletService.save(toSave);
+        var statusCode = resultPair.isNew() ? HttpStatus.CREATED : HttpStatus.OK;
+        return ResponseEntity.status(statusCode).body(resultPair.contentletEntity());
     }
 
     @DeleteMapping("/{id}")
-    Mono<Void> deleteContentlet(@PathVariable String id) {
-        return contentletService.deleteById(id)
-                .then(Mono.empty());
+    void deleteContentlet(@PathVariable String id) {
+        contentletService.deleteById(id);
     }
 }

--- a/src/main/java/com/contented/contented/contentlet/ContentletService.java
+++ b/src/main/java/com/contented/contented/contentlet/ContentletService.java
@@ -4,8 +4,6 @@ import com.contented.contented.contentlet.elasticsearch.ContentletIndexer;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.data.elasticsearch.client.elc.EntityAsMap;
 import org.springframework.stereotype.Service;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -27,66 +25,61 @@ public class ContentletService {
         this.transformationHandler = transformationHandler;
     }
 
-    public Mono<ResultPair> save(ContentletEntity contentletEntity) {
+    public ResultPair save(ContentletEntity contentletEntity) {
         log.info("Saving contentlet: `{}`", contentletEntity.getId());
         var toSave = transformationHandler.applyTransformation(contentletEntity);
-        return saveToDB(toSave)
-            .flatMap(resultPair -> saveToES(resultPair.contentletEntity())
-                    .defaultIfEmpty(Collections.EMPTY_LIST) // Is there a better way to handle a potentially empty mono here?
-                .map(indexedElasticSearchEntities -> resultPair)
-            );
+        ResultPair resultPair = saveToDB(toSave);
+        saveToES(resultPair.contentletEntity());
+        return resultPair;
     }
 
-    private Mono<List<EntityAsMap>> saveToES(ContentletEntity contentletEntity) {
-        return contentletIndexer.indexContentlet(contentletEntity)
-            .doOnNext(elasticSearchEntities ->
-                    log.info("Indexed `{}` documents for contentlet: `{}` successfully",
-                        elasticSearchEntities.size(),
-                        contentletEntity.getId()
-                    )
-            );
+    private List<EntityAsMap> saveToES(ContentletEntity contentletEntity) {
+        List<EntityAsMap> elasticSearchEntities = contentletIndexer.indexContentlet(contentletEntity);
+        log.info("Indexed `{}` documents for contentlet: `{}` successfully",
+                elasticSearchEntities.size(),
+                contentletEntity.getId()
+        );
+        return elasticSearchEntities;
     }
 
-    private Mono<ResultPair> saveToDB(ContentletEntity contentletEntity) {
-        return contentletRepository.existsById(contentletEntity.getId())
-            .flatMap(exists -> {
-                boolean isNew = !exists;
-                log.info("Contentlet {} already exists: {}", contentletEntity.getId(), exists);
-                return contentletRepository.save(contentletEntity)
-                    .map(savedContentlet -> new ResultPair(savedContentlet, isNew))
-                    .doOnNext(resultPair -> log.info("Saved contentlet: `{}` successfully", resultPair.contentletEntity().getId()));
-            });
+    private ResultPair saveToDB(ContentletEntity contentletEntity) {
+        boolean exists = contentletRepository.existsById(contentletEntity.getId());
+        boolean isNew = !exists;
+        log.info("Contentlet {} already exists: {}", contentletEntity.getId(), exists);
+        ContentletEntity savedContentlet = contentletRepository.save(contentletEntity);
+        log.info("Saved contentlet: `{}` successfully", savedContentlet.getId());
+        return new ResultPair(savedContentlet, isNew);
     }
 
-    public Mono<String> deleteById(String id) {
+    public String deleteById(String id) {
         log.info("Deleting contentlet: {}", id);
-        return deleteByIdFromDB(id)
-                .then(deleteByIdFromES(id))
-                .doOnSuccess(result -> log.info("Deleted ES records for id: `{}` successfully", id));
+        deleteByIdFromDB(id);
+        deleteByIdFromES(id);
+        log.info("Deleted ES records for id: `{}` successfully", id);
+        return id;
     }
 
-    private Mono<String> deleteByIdFromES(String id) {
+    private String deleteByIdFromES(String id) {
         return contentletIndexer.deleteRecord(id);
     }
 
-    private Mono<Void> deleteByIdFromDB(String id) {
-        return contentletRepository.deleteById(id)
-                .doOnSuccess(result -> log.info("Deleted contentlet: `{}` successfully", id));
+    private void deleteByIdFromDB(String id) {
+        contentletRepository.deleteById(id);
+        log.info("Deleted contentlet: `{}` successfully", id);
     }
 
-    public Mono<ContentletEntity> findById(String id) {
+    public ContentletEntity findById(String id) {
         log.debug("Finding contentlet: {}", id);
-        return contentletRepository.findById(id)
-                .doOnSuccess(result -> {
-                    if (result != null) {
-                        log.debug("Found contentlet: `{}` successfully", id);
-                    } else {
-                        log.debug("contentlet: `{}` not found", id);
-                    }
-                });
+        ContentletEntity result = contentletRepository.findById(id);
+        if (result != null) {
+            log.debug("Found contentlet: `{}` successfully", id);
+        } else {
+            log.debug("contentlet: `{}` not found", id);
+        }
+        return result;
     }
 
-    public Flux<ContentletEntity> findByIds(List<String> ids) {
+    public List<ContentletEntity> findByIds(List<String> ids) {
         log.debug("Finding {} contentlets", ids.size());
         return contentletRepository.findAllById(ids);
     }

--- a/src/main/java/com/contented/contented/contentlet/elasticsearch/ContentletIndexer.java
+++ b/src/main/java/com/contented/contented/contentlet/elasticsearch/ContentletIndexer.java
@@ -8,7 +8,6 @@ import org.springframework.data.elasticsearch.client.elc.EntityAsMap;
 import org.springframework.data.elasticsearch.core.ReactiveElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.stereotype.Component;
-import reactor.core.publisher.Mono;
 
 import java.util.List;
 
@@ -31,22 +30,23 @@ public class ContentletIndexer {
         this.esTransformers = esTransformers;
     }
 
-    public Mono<List<EntityAsMap>> indexContentlet(ContentletEntity contentletEntity) {
+    public List<EntityAsMap> indexContentlet(ContentletEntity contentletEntity) {
         return esTransformers.stream()
                 .filter(esRecordTransformer -> esRecordTransformer.test(contentletEntity))
                 .findFirst()
                 .map(esRecordTransformer -> {
                     var transformedEntities = esRecordTransformer.transform(contentletEntity);
                     return reactiveElasticsearchOperations.saveAll(transformedEntities, indexCoordinates)
-                        .collectList();
+                        .collectList()
+                        .block();
                 })
                 .orElseGet(() -> {
                     log.warn("No transformer found for contentlet: {}", contentletEntity.getId());
-                    return Mono.empty();
+                    return List.of();
                 });
     }
 
-    public Mono<String> deleteRecord(String id) {
-        return reactiveElasticsearchOperations.delete(id, indexCoordinates);
+    public String deleteRecord(String id) {
+        return reactiveElasticsearchOperations.delete(id, indexCoordinates).block();
     }
 }

--- a/src/main/java/com/contented/contented/contentlet/elasticsearch/IndexController.java
+++ b/src/main/java/com/contented/contented/contentlet/elasticsearch/IndexController.java
@@ -5,7 +5,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import reactor.core.publisher.Mono;
 
 @RestController
 @RequestMapping(IndexController.INDEX_PATH)
@@ -21,9 +20,8 @@ public class IndexController {
 
     // TODO: Temporary, A better design would allow for creating any index name, and then assign an alias to it.
     @PutMapping("/create")
-    public Mono<ResponseEntity> createIndex() {
-        return elasticSearchIndexCreator.createIndex().map(
-            result -> result ? ResponseEntity.ok().build() : ResponseEntity.internalServerError().build()
-        );
+    public ResponseEntity createIndex() {
+        boolean result = elasticSearchIndexCreator.createIndex().block();
+        return result ? ResponseEntity.ok().build() : ResponseEntity.internalServerError().build();
     }
 }

--- a/src/main/java/com/contented/contented/contentlet/elasticsearch/SearchController.java
+++ b/src/main/java/com/contented/contented/contentlet/elasticsearch/SearchController.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import reactor.core.publisher.Mono;
 
 import java.io.ByteArrayInputStream;
 import java.util.List;
@@ -34,22 +33,20 @@ public class SearchController {
     }
 
     @PostMapping("/withcontent")
-    public Mono<SearchResultsWithContent<EntityAsMap>> searchWithContent(@RequestBody String searchRequestJSON) {
+    public SearchResultsWithContent<EntityAsMap> searchWithContent(@RequestBody String searchRequestJSON) {
 
         SearchRequest request = builderFromJSON(searchRequestJSON)
             .index(indexCoordinates.getIndexName()).build();
 
-        return reactiveElasticsearchClient.search(request, EntityAsMap.class)
-            .flatMap(response -> {
-                List<String> extractedIds = response.hits().hits().stream()
-                    .map(hit -> (String) hit.source().get("id"))
-                    .toList();
+        SearchResponse<EntityAsMap> response = reactiveElasticsearchClient.search(request, EntityAsMap.class).block();
 
-                return contentletService.findByIds(extractedIds)
-                    .collectList()
-                    .map(contentlets -> new SearchResultsWithContent<>((SearchResponse<EntityAsMap>) response, contentlets));
+        List<String> extractedIds = response.hits().hits().stream()
+            .map(hit -> (String) hit.source().get("id"))
+            .toList();
 
-            });
+        List<ContentletEntity> contentlets = contentletService.findByIds(extractedIds);
+
+        return new SearchResultsWithContent<>(response, contentlets);
     }
 
     private SearchRequest.Builder builderFromJSON(String searchRequestJSON) {

--- a/src/test/java/com/contented/contented/contentlet/AbstractContentletControllerTests.java
+++ b/src/test/java/com/contented/contented/contentlet/AbstractContentletControllerTests.java
@@ -3,7 +3,7 @@ package com.contented.contented.contentlet;
 import org.junit.jupiter.api.BeforeAll;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.boot.test.web.client.TestRestTemplate;
 
 public abstract class AbstractContentletControllerTests {
 
@@ -13,16 +13,16 @@ public abstract class AbstractContentletControllerTests {
     @Autowired
     protected ContentletRepository contentletRepository;
 
-    protected WebTestClient contentletEndpointClient;
+    protected TestRestTemplate contentletEndpointClient;
 
     @BeforeAll()
     void beforeAll() {
         contentletEndpointClient = createContentletsEndpointClient(port);
     }
 
-    public static WebTestClient createContentletsEndpointClient(int port) {
+    public static TestRestTemplate createContentletsEndpointClient(int port) {
         var baseURL = String.format("http://localhost:%s/%s", port, ContentletController.CONTENTLETS_PATH);
-        return WebTestClient.bindToServer().baseUrl(baseURL).build();
+        return new TestRestTemplate().withBasicAuth(baseURL);
     }
 
 }

--- a/src/test/java/com/contented/contented/contentlet/ContentletControllerBasicTests.java
+++ b/src/test/java/com/contented/contented/contentlet/ContentletControllerBasicTests.java
@@ -6,14 +6,12 @@ import com.contented.contented.contentlet.testutils.StubbingUtils;
 import org.junit.jupiter.api.*;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.web.reactive.server.WebTestClient;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
 
 import static com.contented.contented.contentlet.testutils.MongoDBContainerUtils.mongoDBContainer;
 import static com.contented.contented.contentlet.testutils.MongoDBContainerUtils.startAndRegsiterMongoDBContainer;
@@ -39,7 +37,7 @@ public class ContentletControllerBasicTests extends AbstractContentletController
         startAndRegsiterMongoDBContainer(mongoDBContainer, registry);
     }
 
-    Mono<ContentletEntity> saveOneContentlet() {
+    ContentletEntity saveOneContentlet() {
         return contentletRepository.save(new ContentletEntity("Contentlet1"));
     }
 
@@ -61,7 +59,7 @@ public class ContentletControllerBasicTests extends AbstractContentletController
             // Given
             ContentletDTO toSave = new ContentletDTO("Contentlet2");
 
-            WebTestClient.ResponseSpec response;
+            TestRestTemplate.HttpClientOption response;
 
             @BeforeAll()
             void beforeAll() {
@@ -84,15 +82,10 @@ public class ContentletControllerBasicTests extends AbstractContentletController
             void should_have_saved_the_contentlet_to_the_database() {
 
                 // Then contentletRepository should return the saved contentlet
-                StepVerifier.create(contentletRepository.findById(toSave.getId()))
+                ContentletEntity savedContentlet = contentletRepository.findById(toSave.getId());
 
-                        .expectNextMatches(savedContentlet -> {
-                            assertThat(savedContentlet).isNotNull();
-                            assertThat(savedContentlet.getId()).isEqualTo(toSave.getId());
-                            return true;
-                        })
-                        .verifyComplete();
-
+                assertThat(savedContentlet).isNotNull();
+                assertThat(savedContentlet.getId()).isEqualTo(toSave.getId());
             }
 
             @Nested
@@ -100,7 +93,7 @@ public class ContentletControllerBasicTests extends AbstractContentletController
             @DisplayName("when saving a contentlet with an existing id")
             class SaveAContentletWithAnExistingId {
 
-                static WebTestClient.ResponseSpec response;
+                static TestRestTemplate.HttpClientOption response;
 
                 @BeforeAll()
                 void beforeAll() {
@@ -123,15 +116,10 @@ public class ContentletControllerBasicTests extends AbstractContentletController
                 void should_have_saved_the_contentlet_to_the_database() {
 
                     // Then contentletRepository should return the saved contentlet
-                    StepVerifier.create(contentletRepository.findById(toSave.getId()))
+                    ContentletEntity savedContentlet = contentletRepository.findById(toSave.getId());
 
-                            .expectNextMatches(savedContentlet -> {
-                                assertThat(savedContentlet).isNotNull();
-                                assertThat(savedContentlet.getId()).isEqualTo(toSave.getId());
-                                return true;
-                            })
-                            .verifyComplete();
-
+                    assertThat(savedContentlet).isNotNull();
+                    assertThat(savedContentlet.getId()).isEqualTo(toSave.getId());
                 }
             }
 
@@ -148,7 +136,7 @@ public class ContentletControllerBasicTests extends AbstractContentletController
         void should_return_all_saved_contentlets() {
 
             // Given
-            saveOneContentlet().block();
+            saveOneContentlet();
 
             // When
             var response = contentletEndpointClient.get().uri("/all").exchange();
@@ -170,7 +158,7 @@ public class ContentletControllerBasicTests extends AbstractContentletController
         void beforeAll() {
 
             // Given contentlet is saved
-            contentletRepository.save(savedContentlet).block();
+            contentletRepository.save(savedContentlet);
         }
 
         @Nested
@@ -178,7 +166,7 @@ public class ContentletControllerBasicTests extends AbstractContentletController
         @DisplayName("when querying existing content by id")
         class ExistingContent {
 
-            WebTestClient.ResponseSpec response;
+            TestRestTemplate.HttpClientOption response;
 
             @BeforeAll
             void beforeAll() {
@@ -213,7 +201,7 @@ public class ContentletControllerBasicTests extends AbstractContentletController
         @DisplayName("when querying non-existent content by id")
         class NonExistentContent {
 
-            WebTestClient.ResponseSpec response;
+            TestRestTemplate.HttpClientOption response;
 
             @BeforeAll
             void beforeAll() {
@@ -244,7 +232,7 @@ public class ContentletControllerBasicTests extends AbstractContentletController
             // Given
             static ContentletEntity toDelete = new ContentletEntity("Contentlet3");
 
-            static WebTestClient.ResponseSpec response;
+            static TestRestTemplate.HttpClientOption response;
 
             @BeforeAll()
             void beforeAll() {
@@ -253,7 +241,7 @@ public class ContentletControllerBasicTests extends AbstractContentletController
                 StubbingUtils.passThrough_deleteRecord(contentletIndexer);
 
                 // Save the contentlet to the database
-                contentletRepository.save(toDelete).block();
+                contentletRepository.save(toDelete);
 
                 // When
                 response = contentletEndpointClient.delete().uri("/{id}", toDelete.getId()).exchange();
@@ -273,10 +261,8 @@ public class ContentletControllerBasicTests extends AbstractContentletController
             void should_have_deleted_the_contentlet_from_the_database() {
 
                 // Then contentletRepository should not return the deleted contentlet
-                StepVerifier.create(contentletRepository.findById(toDelete.getId()))
-                        .expectNextCount(0)
-                        .verifyComplete();
-
+                ContentletEntity deletedContentlet = contentletRepository.findById(toDelete.getId());
+                assertThat(deletedContentlet).isNull();
             }
         }
 
@@ -286,7 +272,7 @@ public class ContentletControllerBasicTests extends AbstractContentletController
         class DeleteNonExistentContentlet {
 
             // Given
-            static WebTestClient.ResponseSpec response;
+            static TestRestTemplate.HttpClientOption response;
 
             @BeforeAll()
             void beforeAll() {

--- a/src/test/java/com/contented/contented/contentlet/ContentletControllerFieldTests.java
+++ b/src/test/java/com/contented/contented/contentlet/ContentletControllerFieldTests.java
@@ -7,7 +7,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -52,7 +52,7 @@ public class ContentletControllerFieldTests extends AbstractContentletController
                 new SomethingThatLooksLikeAContentlet("Contentlet1",
                     "field1Value", 123);
 
-            WebTestClient.ResponseSpec response;
+            TestRestTemplate.HttpClientOption response;
 
             @BeforeAll
             void when() {
@@ -99,7 +99,7 @@ public class ContentletControllerFieldTests extends AbstractContentletController
 
                 // TBD: Save directly to the DB instead?
                 // When
-                WebTestClient.ResponseSpec response = contentletEndpointClient.put().bodyValue(toSave).exchange();
+                TestRestTemplate.HttpClientOption response = contentletEndpointClient.put().bodyValue(toSave).exchange();
 
                 response.expectStatus().is2xxSuccessful();
             }
@@ -109,7 +109,7 @@ public class ContentletControllerFieldTests extends AbstractContentletController
             @DisplayName("when getting that contentlet with fields")
             class GetAContentlet {
 
-                WebTestClient.ResponseSpec response;
+                TestRestTemplate.HttpClientOption response;
 
                 @BeforeAll
                 void beforeAll() {
@@ -173,7 +173,7 @@ public class ContentletControllerFieldTests extends AbstractContentletController
             @DisplayName("when getting that contentlet with complex fields")
             class GetContentletWithComplexFields {
 
-                WebTestClient.ResponseSpec response;
+                TestRestTemplate.HttpClientOption response;
 
                 @BeforeAll
                 void when() {

--- a/src/test/java/com/contented/contented/contentlet/ContentletControllerSearchIndexTests.java
+++ b/src/test/java/com/contented/contented/contentlet/ContentletControllerSearchIndexTests.java
@@ -15,7 +15,7 @@ import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
 import org.springframework.data.elasticsearch.core.query.Query;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -141,7 +141,7 @@ public class ContentletControllerSearchIndexTests extends AbstractContentletCont
 
             static SomeContentlet toDelete = new SomeContentlet("contentlet1234_deleteme", "Blog", "Delete Me", "Some body");
 
-            static WebTestClient.ResponseSpec response;
+            static TestRestTemplate.ResponseSpec response;
 
             @BeforeAll
             void given() {

--- a/src/test/java/com/contented/contented/contentlet/ContentletServiceIntegrationTests.java
+++ b/src/test/java/com/contented/contented/contentlet/ContentletServiceIntegrationTests.java
@@ -88,7 +88,7 @@ public class ContentletServiceIntegrationTests {
 
                 @BeforeAll
                 void beforeAll() {
-                    contentletService.save(toSave).block();
+                    contentletService.save(toSave);
                     waitForESToAffectChanges();
                 }
 

--- a/src/test/java/com/contented/contented/contentlet/ContentletServiceTest.java
+++ b/src/test/java/com/contented/contented/contentlet/ContentletServiceTest.java
@@ -12,7 +12,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.data.elasticsearch.core.ReactiveElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
-import reactor.core.publisher.Mono;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -76,10 +75,10 @@ public class ContentletServiceTest {
                 passthroughContentletRepository(repository); // because we reset the repository in afterAll
 
                 // Given
-                when(repository.existsById(Mockito.anyString())).thenReturn(Mono.just(false));
+                when(repository.existsById(Mockito.anyString())).thenReturn(false);
 
                 // when
-                result = contentletService.save(toSave).block();
+                result = contentletService.save(toSave);
             }
 
             @AfterAll
@@ -117,9 +116,9 @@ public class ContentletServiceTest {
                 passthroughContentletRepository(repository); // because we reset the repository in afterAll
 
                 // Given
-                when(repository.existsById(Mockito.anyString())).thenReturn(Mono.just(true));
+                when(repository.existsById(Mockito.anyString())).thenReturn(true);
 
-                result = contentletService.save(toSave).block();
+                result = contentletService.save(toSave);
             }
 
             @AfterAll
@@ -159,7 +158,7 @@ public class ContentletServiceTest {
             @BeforeAll
             void beforeAll() {
 
-                when(repository.existsById(Mockito.anyString())).thenReturn(Mono.just(false));
+                when(repository.existsById(Mockito.anyString())).thenReturn(false);
             }
 
             @NestedPerClass
@@ -168,7 +167,7 @@ public class ContentletServiceTest {
 
                 @BeforeAll
                 void beforeAll() {
-                    contentletService.save(toSave).block();
+                    contentletService.save(toSave);
                 }
 
                 @Test()

--- a/src/test/java/com/contented/contented/contentlet/elasticsearch/ContentletIndexerTest.java
+++ b/src/test/java/com/contented/contented/contentlet/elasticsearch/ContentletIndexerTest.java
@@ -13,10 +13,8 @@ import org.mockito.Mockito;
 import org.springframework.data.elasticsearch.client.elc.EntityAsMap;
 import org.springframework.data.elasticsearch.core.ReactiveElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
-import reactor.test.StepVerifier;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -63,7 +61,7 @@ class ContentletIndexerTest {
                 var saveAllArgumentCaptor = ArgumentCaptor.forClass(Iterable.class);
 
                 // When
-                contentletIndexer.indexContentlet(contentletEntity).block();
+                contentletIndexer.indexContentlet(contentletEntity);
 
                 verify(reactiveElasticsearchOperations).saveAll(saveAllArgumentCaptor.capture(), any(IndexCoordinates.class));
 
@@ -82,7 +80,7 @@ class ContentletIndexerTest {
             @DisplayName("it should return a list of the entities that were saved")
             void shouldReturnAListOfTheEntitiesThatWereSaved() {
                 // When
-                var result = contentletIndexer.indexContentlet(contentletEntity).block();
+                var result = contentletIndexer.indexContentlet(contentletEntity);
 
                 // Then
                 assertThat(result).hasSize(3);
@@ -102,15 +100,13 @@ class ContentletIndexerTest {
                     CONTENT_TYPE_FIELD, "TypeWithNoTransformer"));
 
             @Test
-            @DisplayName("it should return an empty mono")
-            void shouldReturnAnEmptyMono() {
+            @DisplayName("it should return an empty list")
+            void shouldReturnAnEmptyList() {
                 // When
                 var result = contentletIndexer.indexContentlet(contentletEntity);
 
                 // Then
-                StepVerifier.create(result)
-                    .expectComplete()
-                    .verify();
+                assertThat(result).isEmpty();
             }
         }
     }

--- a/src/test/java/com/contented/contented/contentlet/elasticsearch/ElasticSearchDiscoveryTests.java
+++ b/src/test/java/com/contented/contented/contentlet/elasticsearch/ElasticSearchDiscoveryTests.java
@@ -15,7 +15,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.elasticsearch.client.elc.EntityAsMap;
 import org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder;
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient;
-import org.springframework.data.elasticsearch.core.ReactiveElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.index.AliasAction;
 import org.springframework.data.elasticsearch.core.index.AliasActionParameters;
 import org.springframework.data.elasticsearch.core.index.AliasActions;
@@ -28,7 +28,6 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import reactor.test.StepVerifier;
 
 import java.io.ByteArrayInputStream;
 import java.util.List;
@@ -53,13 +52,7 @@ public class ElasticSearchDiscoveryTests {
     ReactiveElasticsearchClient reactiveElasticsearchClient;
 
     @Autowired
-    ReactiveElasticsearchOperations reactiveElasticsearchOperations;
-
-//    @Autowired
-//    ReactiveElasticsearchTemplate reactiveElasticsearchTemplate;
-//
-//    @Autowired
-//    ElasticsearchConverter converter;
+    ElasticsearchOperations elasticsearchOperations;
 
     @DynamicPropertySource
     static void startAndRegisterContainers(DynamicPropertyRegistry registry) {
@@ -210,9 +203,7 @@ public class ElasticSearchDiscoveryTests {
             @BeforeAll
             void when() {
 
-                savedEntity = reactiveElasticsearchOperations.save(toSave, IndexCoordinates.of(INDEX_NAME3))
-                    .block();
-
+                savedEntity = elasticsearchOperations.save(toSave, IndexCoordinates.of(INDEX_NAME3));
                 waitForESToAffectChanges();
             }
 
@@ -235,11 +226,9 @@ public class ElasticSearchDiscoveryTests {
             @DisplayName("the document should be searchable by exact match on the keyword field")
             void the_document_should_be_searchable_by_exact_match_on_the_keyword_field() {
                 CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("id").is(toSave.id()));
-                var results = reactiveElasticsearchOperations.search(criteriaQuery, ESDocument.class, IndexCoordinates.of(INDEX_NAME3))
-                    .collectList()
-                    .block();
-                        assertThat(results).hasSize(1);
-                        assertThat(results.get(0).getContent()).isEqualTo(toSave);
+                var results = elasticsearchOperations.search(criteriaQuery, ESDocument.class, IndexCoordinates.of(INDEX_NAME3));
+                assertThat(results).hasSize(1);
+                assertThat(results.get(0).getContent()).isEqualTo(toSave);
             }
 
             @Test
@@ -250,11 +239,8 @@ public class ElasticSearchDiscoveryTests {
                     .withQuery(q -> q.match(m ->
                         m.field("id").query("ABCDE")
                     )).build();
-                reactiveElasticsearchOperations.search(query, ESDocument.class, IndexCoordinates.of(INDEX_NAME3))
-                    .collectList()
-                    .as(StepVerifier::create)
-                    .assertNext(searchHits -> assertThat(searchHits).hasSize(0))
-                    .verifyComplete();
+                var results = elasticsearchOperations.search(query, ESDocument.class, IndexCoordinates.of(INDEX_NAME3));
+                assertThat(results).hasSize(0);
             }
 
             @Test
@@ -265,14 +251,9 @@ public class ElasticSearchDiscoveryTests {
                     .withQuery(q -> q.match(m ->
                         m.field("field1").query("value1")
                     )).build();
-                reactiveElasticsearchOperations.search(query, ESDocument.class, IndexCoordinates.of(INDEX_NAME3))
-                    .collectList()
-                    .as(StepVerifier::create)
-                    .assertNext(searchHits -> {
-                        assertThat(searchHits).hasSize(1);
-                        assertThat(searchHits.get(0).getContent()).isEqualTo(toSave);
-                    })
-                    .verifyComplete();
+                var results = elasticsearchOperations.search(query, ESDocument.class, IndexCoordinates.of(INDEX_NAME3));
+                assertThat(results).hasSize(1);
+                assertThat(results.get(0).getContent()).isEqualTo(toSave);
             }
 
             @Test
@@ -288,11 +269,8 @@ public class ElasticSearchDiscoveryTests {
                     }
                     """;
                 var query = new StringQuery(String.format(queryTemplate,toSave.id()));
-                reactiveElasticsearchOperations.search(query, ESDocument.class, IndexCoordinates.of(INDEX_NAME3))
-                    .collectList()
-                    .as(StepVerifier::create)
-                    .assertNext(searchHits -> assertThat(searchHits).size().isGreaterThan(0))
-                    .verifyComplete();
+                var results = elasticsearchOperations.search(query, ESDocument.class, IndexCoordinates.of(INDEX_NAME3));
+                assertThat(results).size().isGreaterThan(0);
             }
 
             @Test
@@ -315,13 +293,9 @@ public class ElasticSearchDiscoveryTests {
                 builder.withJson(new ByteArrayInputStream(queryString.getBytes()));
                 SearchRequest searchRequest = builder.index(INDEX_NAME3).build();
 
-                reactiveElasticsearchClient.search(searchRequest, EntityAsMap.class)
-                    .as(StepVerifier::create)
-                    .assertNext(response ->
-                        assertThat(response.hits()).isNotNull()
-                            .satisfies(hits -> assertThat(hits.total().value()).isGreaterThan(0))
-                    )
-                    .verifyComplete();
+                var response = reactiveElasticsearchClient.search(searchRequest, EntityAsMap.class);
+                assertThat(response.hits()).isNotNull()
+                    .satisfies(hits -> assertThat(hits.total().value()).isGreaterThan(0));
             }
 
             @NestedPerClass
@@ -336,8 +310,7 @@ public class ElasticSearchDiscoveryTests {
                     aliasActions.add(new AliasAction.Add(AliasActionParameters.builder()
                         .withIndices(INDEX_NAME3)
                         .withAliases(ALIAS_NAME).build()));
-                    reactiveElasticsearchOperations.indexOps(IndexCoordinates.of(INDEX_NAME3)).alias(aliasActions)
-                        .block();
+                    elasticsearchOperations.indexOps(IndexCoordinates.of(INDEX_NAME3)).alias(aliasActions);
 
                 }
 
@@ -346,14 +319,9 @@ public class ElasticSearchDiscoveryTests {
                 void then_the_document_should_be_searchable_via_alias() {
 
                     CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("id").is(toSave.id()));
-                    reactiveElasticsearchOperations.search(criteriaQuery, ESDocument.class, IndexCoordinates.of(ALIAS_NAME))
-                        .collectList()
-                        .as(StepVerifier::create)
-                        .assertNext(searchHits -> {
-                            assertThat(searchHits).hasSize(1);
-                            assertThat(searchHits.get(0).getContent()).isEqualTo(toSave);
-                        })
-                        .verifyComplete();
+                    var results = elasticsearchOperations.search(criteriaQuery, ESDocument.class, IndexCoordinates.of(ALIAS_NAME));
+                    assertThat(results).hasSize(1);
+                    assertThat(results.get(0).getContent()).isEqualTo(toSave);
                 }
             }
         }
@@ -379,7 +347,7 @@ public class ElasticSearchDiscoveryTests {
                         .index(INDEX_NAME3)
                         .build();
 
-                reactiveElasticsearchClient.bulk(request).block();
+                reactiveElasticsearchClient.bulk(request);
 
                 waitForESToAffectChanges();
             }
@@ -388,9 +356,7 @@ public class ElasticSearchDiscoveryTests {
             @DisplayName("the document should be searchable by exact match on the keyword field")
             void the_document_should_be_searchable_by_exact_match_on_the_keyword_field() {
                 CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("id").is(toSave.id()));
-                var results = reactiveElasticsearchOperations.search(criteriaQuery, ESDocument.class, IndexCoordinates.of(INDEX_NAME3))
-                        .collectList()
-                        .block();
+                var results = elasticsearchOperations.search(criteriaQuery, ESDocument.class, IndexCoordinates.of(INDEX_NAME3));
                 assertThat(results).hasSize(1);
                 assertThat(results.get(0).getContent()).isEqualTo(toSave);
             }

--- a/src/test/java/com/contented/contented/contentlet/elasticsearch/SearchControllerTests.java
+++ b/src/test/java/com/contented/contented/contentlet/elasticsearch/SearchControllerTests.java
@@ -64,7 +64,7 @@ public class SearchControllerTests {
         contentletEndpointClient = AbstractContentletControllerTests.createContentletsEndpointClient(port);
 
         // Create the index! Otherwise queries just return 0 results
-        elasticSearchIndexCreator.createIndex();
+        elasticSearchIndexCreator.createIndex().block();
     }
 
     @NestedPerClass


### PR DESCRIPTION
Related to #13

Switch from using Reactor and Spring Webflux to traditional blocking syntax with Spring MVC.

* **ContentedApplication.java**
  - Remove `Hooks.enableAutomaticContextPropagation()` line from the `main` method.
* **ContentletController.java**
  - Replace `Flux<ContentletEntity>` return type with `List<ContentletEntity>` in `getAll` method.
  - Replace `Mono<ResponseEntity<ContentletEntity>>` return type with `ResponseEntity<ContentletEntity>` in `findById` method.
  - Replace `Mono<ResponseEntity<ContentletEntity>>` return type with `ResponseEntity<ContentletEntity>` in `putContentlet` method.
  - Replace `Mono<Void>` return type with `void` in `deleteContentlet` method.
* **ContentletService.java**
  - Replace `Mono<ResultPair>` return type with `ResultPair` in `save` method.
  - Replace `Mono<List<EntityAsMap>>` return type with `List<EntityAsMap>` in `saveToES` method.
  - Replace `Mono<ResultPair>` return type with `ResultPair` in `saveToDB` method.
  - Replace `Mono<String>` return type with `String` in `deleteById` method.
  - Replace `Mono<String>` return type with `String` in `deleteByIdFromES` method.
  - Replace `Mono<Void>` return type with `void` in `deleteByIdFromDB` method.
  - Replace `Mono<ContentletEntity>` return type with `ContentletEntity` in `findById` method.
  - Replace `Flux<ContentletEntity>` return type with `List<ContentletEntity>` in `findByIds` method.
* **ContentletIndexer.java**
  - Replace `Mono<List<EntityAsMap>>` return type with `List<EntityAsMap>` in `indexContentlet` method.
  - Replace `Mono<String>` return type with `String` in `deleteRecord` method.
* **IndexController.java**
  - Replace `Mono<ResponseEntity>` return type with `ResponseEntity` in `createIndex` method.
* **SearchController.java**
  - Replace `Mono<SearchResultsWithContent<EntityAsMap>>` return type with `SearchResultsWithContent<EntityAsMap>` in `searchWithContent` method.
* **Tests**
  - Replace `Mono` and `Flux` with blocking calls in tests.
  - Replace `WebTestClient` with `TestRestTemplate` in tests.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PaulDMooney/Contented_Java/issues/13?shareId=ddee060c-d6ca-42c5-a902-465688213f2d).