### PR TITLE
feat: Split contentlet write API into POST create + PUT update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Spring Boot 4 (MVC, blocking, virtual threads enabled) content management API on Java 25. Contentlets — schemaless content records — are persisted to MongoDB (system of record) and indexed into Elasticsearch for search. Maven build via the wrapper (`./mvnw`). JSON is Jackson 3 (`tools.jackson` packages; only the `com.fasterxml.jackson.annotation.*` annotations kept their Jackson 2 package).
+Spring Boot 4 (MVC, blocking, virtual threads enabled) content management API on Java 25. Contentlets — schemaless content records — are persisted to Postgres (system of record) and indexed into Elasticsearch for search. Maven build via the wrapper (`./mvnw`). JSON is Jackson 3 (`tools.jackson` packages; only the `com.fasterxml.jackson.annotation.*` annotations kept their Jackson 2 package).
 
 ## Commands
 
@@ -13,27 +13,32 @@ Spring Boot 4 (MVC, blocking, virtual threads enabled) content management API on
 ./mvnw test -Dtest=ContentletServiceTest                  # single test class
 ./mvnw test -Dtest=ContentletServiceTest#someMethod       # single test method
 ./mvnw spring-boot:run               # run the app (start docker-compose services first)
-docker-compose up -d                 # local MongoDB (27017), mongo-express UI (8081), Elasticsearch (9200)
+docker-compose up -d                 # local Postgres (5432), pgAdmin UI (8081), Elasticsearch (9200)
 ```
 
 CI runs `mvn --batch-mode surefire-report:report`.
 
-Most tests are integration tests (tagged `IntegrationTest`, see `TestTypeTags`) that spin up real MongoDB/Elasticsearch containers via Testcontainers, so Docker must be running even for `./mvnw test`.
+Most tests are integration tests (tagged `IntegrationTest`, see `TestTypeTags`) that spin up real Postgres/Elasticsearch containers via Testcontainers, so Docker must be running even for `./mvnw test`.
 
 ## Architecture
 
-The core flow is a dual-write pipeline triggered by `PUT /contentlets` (`ContentletController` → `ContentletService.save`):
+Ids are **intrinsic** (server-generated UUIDv7, assigned in `ContentletService`); clients never supply them. The core flow is a dual-write pipeline with two write entry points:
 
-1. **Inbound transformation** — `TransformationHandler` runs the entity through the *first* `ContentletEntityTransformer` bean whose `test()` predicate matches (e.g. `StandardDMSContentTransformer`, which normalizes legacy DMS fields like `stName`/`contentType`/`inode`/`identifier` and derives the id). No match = entity passes through unchanged.
-2. **MongoDB save** — `ContentletRepository` (blocking `MongoRepository`). Existence is checked first so the controller can return 201 vs 200.
-3. **Elasticsearch indexing** — `ContentletIndexer` picks the *first* matching `ESRecordTransformer` bean (e.g. `BlogTransformer`), which maps one contentlet to **one or more** `EntityAsMap` ES documents. No match = warning logged, nothing indexed (the Mongo save still succeeds).
+- `POST /contentlets` (`ContentletController.createContentlet` → `ContentletService.create`) — create. A client-supplied body id is rejected with `400`; otherwise a UUIDv7 is generated and the response is `201 Created` with a `Location` header.
+- `PUT /contentlets/{id}` (`ContentletController.updateContentlet` → `ContentletService.update`) — update only. The URL id is authoritative; a body id that disagrees with it is rejected with `400`, and an unknown id returns `404` (create-on-missing is deliberately disabled — creation is POST-only).
+
+Both then run the same pipeline:
+
+1. **Inbound transformation** — `TransformationHandler` runs the entity through the *first* `ContentletEntityTransformer` bean whose `test()` predicate matches (e.g. `StandardDMSContentTransformer`, which normalizes fields like `stName`/`contentType`/`identifier` and stamps `modDate`). No match = entity passes through unchanged.
+2. **Postgres save** — `ContentletRepository` (Spring Data JDBC `ListCrudRepository`). `ContentletEntity` implements `Persistable<UUID>` and carries a `@Transient isNew` flag that drives the INSERT-vs-UPDATE choice for assigned ids: `create` sets it `true`, `update` checks `existsById` first (absent → `404`, no save) and sets it `false`.
+3. **Elasticsearch indexing** — `ContentletIndexer` picks the *first* matching `ESRecordTransformer` bean (e.g. `BlogTransformer`), which maps one contentlet to **one or more** `EntityAsMap` ES documents. No match = warning logged, nothing indexed (the Postgres save still succeeds).
 
 Both transformer families are discovered by Spring `List<T>` injection of `@Component` beans and gated by `Predicate.test()` — to support a new content type, add a new transformer bean of either kind; no registration step exists.
 
-`ContentletEntity` is schemaless: an `@Id` plus a `Map<String, Object>` exposed through Jackson's `@JsonAnySetter`/`@JsonAnyGetter`, so arbitrary JSON fields round-trip through the API and MongoDB.
+`ContentletEntity` is schemaless: an `@Id` plus a `Map<String, Object>` exposed through Jackson's `@JsonAnySetter`/`@JsonAnyGetter`, so arbitrary JSON fields round-trip through the API and Postgres.
 
 Other entry points:
-- `POST /search/withcontent` (`SearchController`) — accepts a raw Elasticsearch query JSON body, runs it against the index, then hydrates full contentlets from MongoDB by the ids found in the hits (`SearchResultsWithContent` carries both; it has custom Jackson serializers in the `elasticsearch` package).
+- `POST /search/withcontent` (`SearchController`) — accepts a raw Elasticsearch query JSON body, runs it against the index, then hydrates full contentlets from Postgres by the ids found in the hits (`SearchResultsWithContent` carries both; it has custom Jackson serializers in the `elasticsearch` package).
 - `PUT /index/create` (`IndexController`) — creates the ES index using `src/main/resources/elasticsearch/mappings.json`. Index name and mappings file come from `elasticsearch.index.*` in `application.yaml`; the index name is injected app-wide as a single `IndexCoordinates` bean (`ElasticSearchConfig`).
 
 Swagger UI is available via springdoc at `/swagger-ui/index.html`.
@@ -42,4 +47,4 @@ Swagger UI is available via springdoc at `/swagger-ui/index.html`.
 
 Tests are BDD-style: `@Nested`/`@NestedPerClass` classes named for the scenario ("when saving a new contentlet"), `@DisplayName` on everything, given/when in `@BeforeAll`, one assertion per `@Test`. `@NestedPerClass` (in `testutils`) is `@Nested` + `@TestInstance(PER_CLASS)`, which is what allows `@BeforeAll` on instance methods.
 
-Container setup is shared through `testutils.MongoDBContainerUtils` / `ElasticSearchContainerUtils`: declare a `@Container static` field and register its URI in a `@DynamicPropertySource` method. Controller tests extend `AbstractContentletControllerTests` for a `WebTestClient` bound to the contentlets endpoint (spring-webflux is a test-only dependency for this; replacing it with `RestClient`/`MockMvc` is part of roadmap item 4), and `@MockitoBean` the `ContentletIndexer` when ES isn't under test (stub helpers in `StubbingUtils`).
+Container setup is shared through `testutils.PostgresContainerUtils` / `ElasticSearchContainerUtils`: declare a `@Container static` field and register its URI in a `@DynamicPropertySource` method. Controller tests extend `AbstractContentletControllerTests` for a `WebTestClient` bound to the contentlets endpoint (spring-webflux is a test-only dependency for this; replacing it with `RestClient`/`MockMvc` is part of roadmap item 4), and `@MockitoBean` the `ContentletIndexer` when ES isn't under test (stub helpers in `StubbingUtils`).

--- a/src/main/java/com/contented/contented/contentlet/ContentletController.java
+++ b/src/main/java/com/contented/contented/contentlet/ContentletController.java
@@ -1,9 +1,9 @@
 package com.contented.contented.contentlet;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.List;
 import java.util.UUID;
@@ -37,14 +37,34 @@ public class ContentletController {
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
-    @PutMapping
-    ResponseEntity<ContentletEntity> putContentlet(@RequestBody ContentletDTO contentletDTO) {
-        ContentletEntity toSave = new ContentletEntity(contentletDTO.getId(), contentletDTO.get());
+    @PostMapping
+    ResponseEntity<ContentletEntity> createContentlet(@RequestBody ContentletDTO contentletDTO,
+                                                      UriComponentsBuilder uriBuilder) {
+        // Ids are server-assigned; a client must not supply one when creating.
+        if (contentletDTO.getId() != null) {
+            return ResponseEntity.badRequest().build();
+        }
+        ContentletEntity toSave = new ContentletEntity(null, contentletDTO.get());
 
-        var resultPair = contentletService.save(toSave);
-        var statusCode = resultPair.isNew() ? HttpStatus.CREATED : HttpStatus.OK;
-        return ResponseEntity.status(statusCode)
-                .body(resultPair.contentletEntity());
+        var created = contentletService.create(toSave);
+        var location = uriBuilder.path("/{base}/{id}")
+                .buildAndExpand(CONTENTLETS_PATH, created.getId())
+                .toUri();
+        return ResponseEntity.created(location).body(created);
+    }
+
+    @PutMapping("/{id}")
+    ResponseEntity<ContentletEntity> updateContentlet(@PathVariable UUID id,
+                                                      @RequestBody ContentletDTO contentletDTO) {
+        // The URL is the source of truth for identity; a body id must agree with it.
+        if (contentletDTO.getId() != null && !contentletDTO.getId().equals(id)) {
+            return ResponseEntity.badRequest().build();
+        }
+        ContentletEntity toSave = new ContentletEntity(id, contentletDTO.get());
+
+        return contentletService.update(id, toSave)
+                .map(updated -> ResponseEntity.ok(updated))
+                .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/contented/contented/contentlet/ContentletService.java
+++ b/src/main/java/com/contented/contented/contentlet/ContentletService.java
@@ -26,16 +26,28 @@ public class ContentletService {
         this.transformationHandler = transformationHandler;
     }
 
-    public ResultPair save(ContentletEntity contentletEntity) {
-        log.info("Saving contentlet: `{}`", contentletEntity.getId());
+    public ContentletEntity create(ContentletEntity contentletEntity) {
         var toSave = transformationHandler.applyTransformation(contentletEntity);
-        if (toSave.getId() == null) {
-            toSave.setId(UuidV7.generate());
-            log.info("Assigned new id `{}` to contentlet", toSave.getId());
+        toSave.setId(UuidV7.generate());
+        toSave.setNew(true);
+        var saved = contentletRepository.save(toSave);
+        log.info("Created contentlet: `{}` successfully", saved.getId());
+        saveToES(saved);
+        return saved;
+    }
+
+    public Optional<ContentletEntity> update(UUID id, ContentletEntity contentletEntity) {
+        if (!contentletRepository.existsById(id)) {
+            log.info("Contentlet `{}` not found; nothing to update", id);
+            return Optional.empty();
         }
-        var resultPair = saveToDB(toSave);
-        saveToES(resultPair.contentletEntity());
-        return resultPair;
+        var toSave = transformationHandler.applyTransformation(contentletEntity);
+        toSave.setId(id);
+        toSave.setNew(false);
+        var saved = contentletRepository.save(toSave);
+        log.info("Updated contentlet: `{}` successfully", saved.getId());
+        saveToES(saved);
+        return Optional.of(saved);
     }
 
     private List<EntityAsMap> saveToES(ContentletEntity contentletEntity) {
@@ -48,16 +60,6 @@ public class ContentletService {
             contentletEntity.getId()
         );
         return indexedElasticSearchEntities;
-    }
-
-    private ResultPair saveToDB(ContentletEntity contentletEntity) {
-        boolean exists = contentletRepository.existsById(contentletEntity.getId());
-        boolean isNew = !exists;
-        log.info("Contentlet {} already exists: {}", contentletEntity.getId(), exists);
-        contentletEntity.setNew(isNew);
-        var savedContentlet = contentletRepository.save(contentletEntity);
-        log.info("Saved contentlet: `{}` successfully", savedContentlet.getId());
-        return new ResultPair(savedContentlet, isNew);
     }
 
     public void deleteById(UUID id) {
@@ -90,8 +92,5 @@ public class ContentletService {
     public List<ContentletEntity> findByIds(List<UUID> ids) {
         log.debug("Finding {} contentlets", ids.size());
         return contentletRepository.findAllById(ids);
-    }
-
-    public record ResultPair(ContentletEntity contentletEntity, boolean isNew) {
     }
 }

--- a/src/main/java/com/contented/contented/contentlet/transformation/StandardDMSContentTransformer.java
+++ b/src/main/java/com/contented/contented/contentlet/transformation/StandardDMSContentTransformer.java
@@ -13,30 +13,11 @@ import java.util.Map;
 @Component
 public class StandardDMSContentTransformer implements ContentletEntityTransformer {
 
-    // TODO: Make any of these standard fields of the ContentletEntity class? TBD.
-    // Legacy support field
-    public static final String ST_NAME_FIELD = "stName";
     public static final String CONTENT_TYPE_FIELD = "contentType";
-
-    // Language agnostic identifier. Legacy Support field.
-    public static final String IDENTIFIER_FIELD = "identifier";
 
     public static final String LANGUAGE_FIELD = "language";
 
-    // Language specific identifier. Legacy support field
-    public static final String INODE_FIELD = "inode";
-
     public static final String MODE_DATE_FIELD = "modDate";
-
-    // Legacy support field
-    public static final String LIVE_FIELD = "live";
-
-    public static final String PARENT_DMS_ID_FIELD = "parentDmsId";
-
-    public static final String DMS_ID_FIELD = "dmsId";
-
-    // Legacy support field.
-//    public static final String LANGUAGE_ID_FIELD = "languageId";
 
     public static final String BLOG_VALUE = "Blog";
 
@@ -52,21 +33,13 @@ public class StandardDMSContentTransformer implements ContentletEntityTransforme
     public ContentletEntity transform(ContentletEntity toTransform) {
 
         Map<String, Object> mutableSchemalessData = new HashMap<>(toTransform.getSchemalessData());
-        setContentTypeAndSTName(mutableSchemalessData);
         normalizeLanguage(mutableSchemalessData);
-        setINode(mutableSchemalessData);
-        setIdentifier(mutableSchemalessData);
         setModDate(mutableSchemalessData);
         return new ContentletEntity(toTransform.getId(), Collections.unmodifiableMap(mutableSchemalessData));
     }
 
     private void setModDate(Map<String, Object> mutableSchemalessData) {
         mutableSchemalessData.put(MODE_DATE_FIELD, clock.instant());
-    }
-
-    private void setINode(Map<String, Object> mutableSchemalessData) {
-        mutableSchemalessData.put(INODE_FIELD,
-                mutableSchemalessData.get(DMS_ID_FIELD));
     }
 
     private void normalizeLanguage(Map<String, Object> mutableSchemalessData) {
@@ -80,29 +53,10 @@ public class StandardDMSContentTransformer implements ContentletEntityTransforme
 
     }
 
-    private void setIdentifier(Map<String, Object> mutableSchemalessData) {
-        mutableSchemalessData.put(IDENTIFIER_FIELD,
-                mutableSchemalessData.get(PARENT_DMS_ID_FIELD));
-    }
-
-    private void setContentTypeAndSTName(Map<String, Object> mutableSchemalessData) {
-
-        // One of these two fields must be populated.
-        mutableSchemalessData.computeIfAbsent(CONTENT_TYPE_FIELD,
-                key -> mutableSchemalessData.get(ST_NAME_FIELD));
-        mutableSchemalessData.computeIfAbsent(ST_NAME_FIELD,
-                key -> mutableSchemalessData.get(CONTENT_TYPE_FIELD));
-
-        // TODO: Throw an exception if the two fields don't match.
-    }
-
     @Override
     public boolean test(ContentletEntity contentletEntity) {
-        String stName = (String) contentletEntity.getSchemalessData().get(ST_NAME_FIELD);
         String contentType = (String) contentletEntity.getSchemalessData().get(CONTENT_TYPE_FIELD);
         return SUPPORTED_TYPES.stream()
-                .anyMatch(type ->
-                        type.equalsIgnoreCase(stName) || BLOG_VALUE.equalsIgnoreCase(contentType)
-                );
+                .anyMatch(type -> type.equalsIgnoreCase(contentType));
     }
 }

--- a/src/test/java/com/contented/contented/contentlet/ContentletControllerBasicTests.java
+++ b/src/test/java/com/contented/contented/contentlet/ContentletControllerBasicTests.java
@@ -5,10 +5,14 @@ import com.contented.contented.contentlet.testutils.NestedPerClass;
 import com.contented.contented.contentlet.testutils.StubbingUtils;
 import org.junit.jupiter.api.*;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
 import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.util.UUID;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -49,15 +53,63 @@ public class ContentletControllerBasicTests extends AbstractContentletController
     }
 
     @Nested
-    @DisplayName("PUT endpoint")
-    class PutEndPoint {
+    @DisplayName("POST endpoint")
+    class PostEndPoint {
 
         @NestedPerClass
-        @DisplayName("when saving a new contentlet")
-        class SaveANewContentlet {
+        @DisplayName("when creating a new contentlet")
+        class CreateANewContentlet {
 
-            // Given
-            ContentletDTO toSave = new ContentletDTO(UuidV7.generate());
+            // Given a body with no id (ids are server-assigned)
+            ContentletDTO toCreate = new ContentletDTO();
+
+            EntityExchangeResult<ContentletEntity> result;
+
+            @BeforeAll()
+            void beforeAll() {
+                mockContentletIndexer();
+                toCreate.add("field1", "value1");
+
+                // When
+                result = contentletEndpointClient.post()
+                        .bodyValue(toCreate)
+                        .exchange()
+                        .expectBody(ContentletEntity.class)
+                        .returnResult();
+            }
+
+            @Test
+            @DisplayName("it should return a 201 CREATED status code")
+            void should_return_a_201_CREATED_status_code() {
+                assertThat(result.getStatus()).isEqualTo(HttpStatus.CREATED);
+            }
+
+            @Test
+            @DisplayName("it should return a Location header for the new contentlet")
+            void should_return_a_location_header() {
+                assertThat(result.getResponseHeaders().getLocation()).isNotNull();
+            }
+
+            @Test
+            @DisplayName("it should return the contentlet with a generated id")
+            void should_return_a_generated_id() {
+                assertThat(result.getResponseBody().getId()).isNotNull();
+            }
+
+            @Test
+            @DisplayName("it should have saved the contentlet to the database")
+            void should_have_saved_the_contentlet_to_the_database() {
+                var savedContentlet = contentletRepository.findById(result.getResponseBody().getId());
+
+                assertThat(savedContentlet).isPresent();
+            }
+        }
+
+        @NestedPerClass
+        @DisplayName("when creating a contentlet with a client-supplied id")
+        class CreateWithSuppliedId {
+
+            ContentletDTO toCreate = new ContentletDTO(UuidV7.generate());
 
             WebTestClient.ResponseSpec response;
 
@@ -65,66 +117,109 @@ public class ContentletControllerBasicTests extends AbstractContentletController
             void beforeAll() {
                 mockContentletIndexer();
                 // When
-                response = contentletEndpointClient.put().bodyValue(toSave).exchange();
+                response = contentletEndpointClient.post().bodyValue(toCreate).exchange();
             }
 
             @Test
-            @DisplayName("it should return a 201 CREATED status code")
-            void should_return_a_201_CREATED_status_code() {
+            @DisplayName("it should return a 400 BAD REQUEST status code")
+            void should_return_a_400() {
+                response.expectStatus().isBadRequest();
+            }
+        }
+    }
 
-                // Then
-                response.expectStatus()
-                        .isCreated();
+    @Nested
+    @DisplayName("PUT /{id} endpoint")
+    class PutEndPoint {
+
+        @NestedPerClass
+        @DisplayName("when updating a contentlet that exists")
+        class UpdateExistingContentlet {
+
+            // Given an existing contentlet
+            ContentletEntity existing = new ContentletEntity(UuidV7.generate());
+
+            WebTestClient.ResponseSpec response;
+
+            @BeforeAll()
+            void beforeAll() {
+                mockContentletIndexer();
+                contentletRepository.save(existing);
+
+                ContentletDTO update = new ContentletDTO(existing.getId());
+                update.add("field1", "updatedValue");
+
+                // When
+                response = contentletEndpointClient.put()
+                        .uri("/{id}", existing.getId())
+                        .bodyValue(update)
+                        .exchange();
             }
 
             @Test
-            @DisplayName("it should have saved the contentlet to the database")
-            void should_have_saved_the_contentlet_to_the_database() {
+            @DisplayName("it should return a 200 OK status code")
+            void should_return_a_200_OK_status_code() {
+                response.expectStatus().isOk();
+            }
 
-                // Then contentletRepository should return the saved contentlet
-                var savedContentlet = contentletRepository.findById(toSave.getId());
+            @Test
+            @DisplayName("it should have updated the contentlet in the database")
+            void should_have_updated_the_contentlet() {
+                var savedContentlet = contentletRepository.findById(existing.getId());
 
                 assertThat(savedContentlet).isPresent();
-                assertThat(savedContentlet.get().getId()).isEqualTo(toSave.getId());
+                assertThat((String) savedContentlet.get().get("field1")).isEqualTo("updatedValue");
             }
-
-            @Nested
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-            @DisplayName("when saving a contentlet with an existing id")
-            class SaveAContentletWithAnExistingId {
-
-                static WebTestClient.ResponseSpec response;
-
-                @BeforeAll()
-                void beforeAll() {
-                    mockContentletIndexer();
-                    // When
-                    response = contentletEndpointClient.put().bodyValue(toSave).exchange();
-                }
-
-                @Test
-                @DisplayName("it should return a 200 CREATED status code")
-                void should_return_a_200_OK_status_code() {
-
-                    // Then
-                    response.expectStatus()
-                            .isOk();
-                }
-
-                @Test
-                @DisplayName("it should have saved the contentlet to the database")
-                void should_have_saved_the_contentlet_to_the_database() {
-
-                    // Then contentletRepository should return the saved contentlet
-                    var savedContentlet = contentletRepository.findById(toSave.getId());
-
-                    assertThat(savedContentlet).isPresent();
-                    assertThat(savedContentlet.get().getId()).isEqualTo(toSave.getId());
-                }
-            }
-
         }
 
+        @NestedPerClass
+        @DisplayName("when updating a contentlet that does not exist")
+        class UpdateNonExistentContentlet {
+
+            WebTestClient.ResponseSpec response;
+
+            @BeforeAll()
+            void beforeAll() {
+                mockContentletIndexer();
+                UUID id = UuidV7.generate();
+
+                // When
+                response = contentletEndpointClient.put()
+                        .uri("/{id}", id)
+                        .bodyValue(new ContentletDTO(id))
+                        .exchange();
+            }
+
+            @Test
+            @DisplayName("it should return a 404 NOT FOUND status code")
+            void should_return_a_404() {
+                response.expectStatus().isNotFound();
+            }
+        }
+
+        @NestedPerClass
+        @DisplayName("when the body id does not match the URL id")
+        class UpdateWithMismatchedBodyId {
+
+            WebTestClient.ResponseSpec response;
+
+            @BeforeAll()
+            void beforeAll() {
+                mockContentletIndexer();
+
+                // When the body carries a different id than the URL
+                response = contentletEndpointClient.put()
+                        .uri("/{id}", UuidV7.generate())
+                        .bodyValue(new ContentletDTO(UuidV7.generate()))
+                        .exchange();
+            }
+
+            @Test
+            @DisplayName("it should return a 400 BAD REQUEST status code")
+            void should_return_a_400() {
+                response.expectStatus().isBadRequest();
+            }
+        }
     }
 
     @Nested

--- a/src/test/java/com/contented/contented/contentlet/ContentletControllerFieldTests.java
+++ b/src/test/java/com/contented/contented/contentlet/ContentletControllerFieldTests.java
@@ -40,20 +40,19 @@ public class ContentletControllerFieldTests extends AbstractContentletController
 
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    @DisplayName("PUT endpoint")
-    class PutEndPoint {
+    @DisplayName("POST endpoint")
+    class PostEndPoint {
 
         @Nested
         @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-        @DisplayName("when saving a contentlet with fields")
-        class SaveANewContentlet {
+        @DisplayName("when creating a contentlet with fields")
+        class CreateANewContentlet {
 
-            // Given
+            // Given a body with no id (ids are server-assigned)
             SomethingThatLooksLikeAContentlet toSave =
-                new SomethingThatLooksLikeAContentlet(UuidV7.generate().toString(),
-                    "field1Value", 123);
+                new SomethingThatLooksLikeAContentlet(null, "field1Value", 123);
 
-            WebTestClient.ResponseSpec response;
+            UUID createdId;
 
             @BeforeAll
             void when() {
@@ -62,16 +61,17 @@ public class ContentletControllerFieldTests extends AbstractContentletController
                 StubbingUtils.passThrough_indexContentlet(contentletIndexer);
 
                 // When
-                response = contentletEndpointClient.put().bodyValue(toSave).exchange();
-
-                response.expectStatus().is2xxSuccessful();
+                createdId = contentletEndpointClient.post().bodyValue(toSave).exchange()
+                    .expectStatus().isCreated()
+                    .expectBody(ContentletEntity.class)
+                    .returnResult().getResponseBody().getId();
             }
 
             @Test
             @DisplayName("it should save the contentlet with its given fields")
             void it_should_save_the_contentlet_with_its_given_fields() {
 
-                ContentletEntity savedEntity = contentletRepository.findById(UUID.fromString(toSave.id())).orElseThrow();
+                ContentletEntity savedEntity = contentletRepository.findById(createdId).orElseThrow();
 
                 assertThat((String) savedEntity.get("field1")).isEqualTo(toSave.field1());
                 assertThat((Integer) savedEntity.get("field2")).isEqualTo(toSave.field2());
@@ -87,10 +87,11 @@ public class ContentletControllerFieldTests extends AbstractContentletController
         @TestInstance(TestInstance.Lifecycle.PER_CLASS)
         @DisplayName("given a contentlet with fields was saved")
         class GivenAContentletWithFieldsWasSaved {
-            // Given
+            // Given a body with no id (ids are server-assigned)
             SomethingThatLooksLikeAContentlet toSave =
-                new SomethingThatLooksLikeAContentlet(UuidV7.generate().toString(),
-                    "field1Value", 123);
+                new SomethingThatLooksLikeAContentlet(null, "field1Value", 123);
+
+            UUID createdId;
 
             @BeforeAll
             void beforeAll() {
@@ -98,11 +99,11 @@ public class ContentletControllerFieldTests extends AbstractContentletController
                 // Not concerned with indexing, mock the indexer to just pass through
                 StubbingUtils.passThrough_indexContentlet(contentletIndexer);
 
-                // TBD: Save directly to the DB instead?
                 // When
-                WebTestClient.ResponseSpec response = contentletEndpointClient.put().bodyValue(toSave).exchange();
-
-                response.expectStatus().is2xxSuccessful();
+                createdId = contentletEndpointClient.post().bodyValue(toSave).exchange()
+                    .expectStatus().isCreated()
+                    .expectBody(ContentletEntity.class)
+                    .returnResult().getResponseBody().getId();
             }
 
             @Nested
@@ -120,7 +121,7 @@ public class ContentletControllerFieldTests extends AbstractContentletController
 
                     // When
                     response = contentletEndpointClient.get()
-                        .uri("/" + toSave.id())
+                        .uri("/" + createdId)
                         .exchange();
                 }
 
@@ -132,7 +133,7 @@ public class ContentletControllerFieldTests extends AbstractContentletController
                     response.expectStatus().is2xxSuccessful()
                         .expectBody(SomethingThatLooksLikeAContentlet.class)
                         .value(contentlet -> {
-                            assertThat(contentlet.id()).isEqualTo(toSave.id());
+                            assertThat(contentlet.id()).isEqualTo(createdId.toString());
                             assertThat(contentlet.field1()).isEqualTo(toSave.field1());
                             assertThat(contentlet.field2()).isEqualTo(toSave.field2());
                         });
@@ -152,10 +153,12 @@ public class ContentletControllerFieldTests extends AbstractContentletController
             }
 
             ContentletWithComplexFields toSave = new ContentletWithComplexFields(
-                UuidV7.generate().toString(),
+                null,
                 List.of("string1", "string2"),
                 List.of(new ComplexField("field1Value", 123), new ComplexField("field2Value", 456))
             );
+
+            UUID createdId;
 
             @BeforeAll
             void given() {
@@ -163,9 +166,11 @@ public class ContentletControllerFieldTests extends AbstractContentletController
                 // Not concerned with indexing, mock the indexer to just pass through
                 StubbingUtils.passThrough_indexContentlet(contentletIndexer);
 
-                // Given
-                contentletEndpointClient.put().bodyValue(toSave).exchange()
-                    .expectStatus().is2xxSuccessful();
+                // Given a body with no id (ids are server-assigned)
+                createdId = contentletEndpointClient.post().bodyValue(toSave).exchange()
+                    .expectStatus().isCreated()
+                    .expectBody(ContentletEntity.class)
+                    .returnResult().getResponseBody().getId();
 
             }
 
@@ -184,7 +189,7 @@ public class ContentletControllerFieldTests extends AbstractContentletController
 
                     // When
                     response = contentletEndpointClient.get()
-                        .uri("/" + toSave.id())
+                        .uri("/" + createdId)
                         .exchange();
 
                 }
@@ -197,7 +202,7 @@ public class ContentletControllerFieldTests extends AbstractContentletController
                     response.expectStatus().is2xxSuccessful()
                         .expectBody(ContentletWithComplexFields.class)
                         .value(contentlet -> {
-                            assertThat(contentlet.id()).isEqualTo(toSave.id());
+                            assertThat(contentlet.id()).isEqualTo(createdId.toString());
                             assertThat(contentlet.strings()).isEqualTo(toSave.strings());
                             assertThat(contentlet.stuff()).isEqualTo(toSave.stuff());
                         });

--- a/src/test/java/com/contented/contented/contentlet/ContentletControllerSearchIndexTests.java
+++ b/src/test/java/com/contented/contented/contentlet/ContentletControllerSearchIndexTests.java
@@ -22,6 +22,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.List;
+import java.util.UUID;
 
 import static com.contented.contented.contentlet.elasticsearch.ElasticSearchConfig.INDEX_PROPERTY_KEY;
 import static com.contented.contented.contentlet.elasticsearch.ElasticSearchIndexCreator.MAPPINGS_FILE_PROPERTY_KEY;
@@ -72,18 +73,24 @@ public class ContentletControllerSearchIndexTests extends AbstractContentletCont
     }
 
     @NestedPerClass
-    @DisplayName("PUT endpoint")
-    class PutEndpoint {
+    @DisplayName("POST endpoint")
+    class PostEndpoint {
         @NestedPerClass
         @DisplayName("Given content that is indexed by its identifier was saved")
         class GivenContentIndexedByIdentifier {
 
-            SomeContentlet toSave = new SomeContentlet(UuidV7.generate().toString(), "Blog", "Some title", "Some body");
+            // Given a body with no id (ids are server-assigned)
+            SomeContentlet toSave = new SomeContentlet(null, "Blog", "Some title", "Some body");
+
+            UUID createdId;
 
             @BeforeAll
             void given() {
-                contentletEndpointClient.put().bodyValue(toSave).exchange().expectStatus().isCreated();
-                waitForESDocumentCount(elasticsearchOperations, IndexCoordinates.of(INDEX_NAME), toSave.id(), 1);
+                createdId = contentletEndpointClient.post().bodyValue(toSave).exchange()
+                    .expectStatus().isCreated()
+                    .expectBody(ContentletEntity.class)
+                    .returnResult().getResponseBody().getId();
+                waitForESDocumentCount(elasticsearchOperations, IndexCoordinates.of(INDEX_NAME), createdId.toString(), 1);
             }
 
             @NestedPerClass
@@ -113,7 +120,7 @@ public class ContentletControllerSearchIndexTests extends AbstractContentletCont
 
                 @BeforeAll
                 void when() {
-                    CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("id").is(toSave.id()));
+                    CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("id").is(createdId.toString()));
                     results = elasticsearchOperations.search(criteriaQuery, EntityAsMap.class, IndexCoordinates.of(INDEX_NAME))
                             .getSearchHits();
 
@@ -123,7 +130,7 @@ public class ContentletControllerSearchIndexTests extends AbstractContentletCont
                 @DisplayName("Then a hit with the same identifier is returned")
                 void thenContentIsReturned() {
                     Assertions.assertThat(results).hasSize(1);
-                    Assertions.assertThat(results.get(0).getContent()).hasFieldOrPropertyWithValue("id", toSave.id());
+                    Assertions.assertThat(results.get(0).getContent()).hasFieldOrPropertyWithValue("id", createdId.toString());
                 }
             }
         }
@@ -137,14 +144,20 @@ public class ContentletControllerSearchIndexTests extends AbstractContentletCont
         @DisplayName("Given content that is indexed by its identifier was saved")
         class GivenContentIndexedByIdentifier {
 
-            static SomeContentlet toDelete = new SomeContentlet(UuidV7.generate().toString(), "Blog", "Delete Me", "Some body");
+            // Given a body with no id (ids are server-assigned)
+            static SomeContentlet toDelete = new SomeContentlet(null, "Blog", "Delete Me", "Some body");
+
+            static UUID createdId;
 
             static WebTestClient.ResponseSpec response;
 
             @BeforeAll
             void given() {
-                contentletEndpointClient.put().bodyValue(toDelete).exchange().expectStatus().isCreated();
-                waitForESDocumentCount(elasticsearchOperations, IndexCoordinates.of(INDEX_NAME), toDelete.id(), 1);
+                createdId = contentletEndpointClient.post().bodyValue(toDelete).exchange()
+                    .expectStatus().isCreated()
+                    .expectBody(ContentletEntity.class)
+                    .returnResult().getResponseBody().getId();
+                waitForESDocumentCount(elasticsearchOperations, IndexCoordinates.of(INDEX_NAME), createdId.toString(), 1);
             }
 
             @NestedPerClass
@@ -153,16 +166,16 @@ public class ContentletControllerSearchIndexTests extends AbstractContentletCont
 
                 @BeforeAll
                 void when() {
-                    response = contentletEndpointClient.delete().uri("/{id}", toDelete.id()).exchange();
+                    response = contentletEndpointClient.delete().uri("/{id}", createdId).exchange();
 
-                    waitForESDocumentCount(elasticsearchOperations, IndexCoordinates.of(INDEX_NAME), toDelete.id(), 0);
+                    waitForESDocumentCount(elasticsearchOperations, IndexCoordinates.of(INDEX_NAME), createdId.toString(), 0);
                 }
 
 //                @Disabled
                 @Test
                 @DisplayName("then the content should not longer be found when searching by its identifier")
                 void then_the_content_should_not_longer_be_found() {
-                    CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("id").is(toDelete.id()));
+                    CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("id").is(createdId.toString()));
                     List<SearchHit<EntityAsMap>> results = elasticsearchOperations.search(criteriaQuery, EntityAsMap.class, IndexCoordinates.of(INDEX_NAME))
                             .getSearchHits();
 

--- a/src/test/java/com/contented/contented/contentlet/ContentletServiceIntegrationTests.java
+++ b/src/test/java/com/contented/contented/contentlet/ContentletServiceIntegrationTests.java
@@ -73,14 +73,13 @@ public class ContentletServiceIntegrationTests {
         @DisplayName("Given content that matches criteria for elastic search transformations")
         class SavingContentletWithESTransformations {
 
-            // stName = "Blog" will match criteria for a transformation
+            // contentType = "Blog" will match criteria for a transformation
             ContentletEntity toSave = new ContentletEntity(null,
                 Map.ofEntries(
                     entry("language", "en"),
-                    entry("stName", "Blog"),
+                    entry("contentType", "Blog"),
                     entry("title", "Blog Title"),
-                    entry("slug", "blog-slug"),
-                    entry("parentDmsId", "parentDmsIdABCDE")));
+                    entry("slug", "blog-slug")));
 
             @NestedPerClass
             @DisplayName("when saving contentlet")

--- a/src/test/java/com/contented/contented/contentlet/ContentletServiceIntegrationTests.java
+++ b/src/test/java/com/contented/contented/contentlet/ContentletServiceIntegrationTests.java
@@ -74,7 +74,7 @@ public class ContentletServiceIntegrationTests {
         class SavingContentletWithESTransformations {
 
             // stName = "Blog" will match criteria for a transformation
-            ContentletEntity toSave = new ContentletEntity(UuidV7.generate(),
+            ContentletEntity toSave = new ContentletEntity(null,
                 Map.ofEntries(
                     entry("language", "en"),
                     entry("stName", "Blog"),
@@ -86,16 +86,18 @@ public class ContentletServiceIntegrationTests {
             @DisplayName("when saving contentlet")
             class WhenSavingContentlet {
 
+                ContentletEntity created;
+
                 @BeforeAll
                 void beforeAll() {
-                    contentletService.save(toSave);
-                    waitForESDocumentCount(elasticsearchOperations, indexCoordinates, toSave.getId().toString(), 1);
+                    created = contentletService.create(toSave);
+                    waitForESDocumentCount(elasticsearchOperations, indexCoordinates, created.getId().toString(), 1);
                 }
 
                 @Test
                 @DisplayName("the elasticsearch record's _source should contain the transformations")
                 void es_should_contain_transformations() {
-                    CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("id").is(toSave.getId().toString()));
+                    CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("id").is(created.getId().toString()));
                     var results = elasticsearchOperations.search(criteriaQuery, EntityAsMap.class, indexCoordinates).getSearchHits();
 
                     var hitSource = Objects.requireNonNull(results).get(0).getContent();

--- a/src/test/java/com/contented/contented/contentlet/ContentletServiceTest.java
+++ b/src/test/java/com/contented/contented/contentlet/ContentletServiceTest.java
@@ -85,9 +85,8 @@ public class ContentletServiceTest {
 
         ContentletEntity toCreate = new ContentletEntity(null,
             Map.ofEntries(
-                entry("language", "en"),
-                entry("stName", "Blog"),
-                entry("parentDmsId", "parentDmsIdABCDE")));
+                entry("language", "EN"),
+                entry("contentType", "Blog")));
 
         @BeforeAll
         void beforeAll() {
@@ -108,9 +107,9 @@ public class ContentletServiceTest {
 
             // Some expected Transformations
             assertThat(savedValue.getSchemalessData())
-                .hasEntrySatisfying("contentType", value -> assertThat(value).isEqualTo("Blog"));
+                .hasEntrySatisfying("language", value -> assertThat(value).isEqualTo("en"));
             assertThat(savedValue.getSchemalessData())
-                .hasEntrySatisfying("identifier", value -> assertThat(value).isEqualTo("parentDmsIdABCDE"));
+                .containsKey("modDate");
         }
     }
 

--- a/src/test/java/com/contented/contented/contentlet/ContentletServiceTest.java
+++ b/src/test/java/com/contented/contented/contentlet/ContentletServiceTest.java
@@ -4,7 +4,6 @@ import com.contented.contented.contentlet.elasticsearch.ContentletIndexer;
 import com.contented.contented.contentlet.elasticsearch.transformation.BlogTransformer;
 import com.contented.contented.contentlet.testutils.NestedPerClass;
 import com.contented.contented.contentlet.transformation.StandardDMSContentTransformer;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +17,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import static com.contented.contented.contentlet.testutils.StubbingUtils.passthroughContentletRepository;
@@ -29,166 +29,162 @@ import static org.mockito.Mockito.*;
 @DisplayName("ContentletService")
 public class ContentletServiceTest {
 
+    static ContentletService newServiceWith(ContentletRepository repository) {
+        passthroughContentletRepository(repository);
+        var elasticsearchOperations = Mockito.mock(ElasticsearchOperations.class);
+        passthroughElasticSearchOperations(elasticsearchOperations);
+        var contentletIndexer = new ContentletIndexer(elasticsearchOperations, mock(IndexCoordinates.class), List.of(new BlogTransformer()));
+        Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
+        var transformationHandler = new TransformationHandler(List.of(new StandardDMSContentTransformer(clock)));
+        return new ContentletService(repository, contentletIndexer, transformationHandler);
+    }
+
     @NestedPerClass
-    @DisplayName("save")
-    class Save {
+    @DisplayName("create")
+    class Create {
 
+        ContentletRepository repository = Mockito.mock(ContentletRepository.class);
         ContentletService contentletService;
-        ContentletRepository repository;
 
-        ContentletIndexer contentletIndexer;
-
-        ElasticsearchOperations elasticsearchOperations;
-
-        ContentletEntity toSave = new ContentletEntity(UuidV7.generate());
-
-        void verifyContentletSaved() {
-
-            // Could be a better test if we didn't have to know what ContentletRepository calls were being made.
-            // Then we could change out the calls and know the behavior was still correct.
-            verify(repository,times(1)).save(toSave);
-        }
-
-        void assertSameContentletSaved(ContentletEntity saved) {
-            assertThat(saved.getId()).isEqualTo(toSave.getId());
-        }
+        ContentletEntity toCreate = new ContentletEntity(null);
+        ContentletEntity created;
 
         @BeforeAll
         void beforeAll() {
-            repository = Mockito.mock(ContentletRepository.class);
-            passthroughContentletRepository(repository);
-            elasticsearchOperations = Mockito.mock(ElasticsearchOperations.class);
-            passthroughElasticSearchOperations(elasticsearchOperations);
-            contentletIndexer = new ContentletIndexer(elasticsearchOperations, mock(IndexCoordinates.class), List.of(new BlogTransformer()));
-            Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
-            var transformationHandler = new TransformationHandler(List.of(new StandardDMSContentTransformer(clock)));
-            contentletService = new ContentletService(repository, contentletIndexer, transformationHandler);
+            contentletService = newServiceWith(repository);
+
+            // When
+            created = contentletService.create(toCreate);
         }
 
-        @NestedPerClass
-        @DisplayName("when saving contentlet that does not exist")
-        class SavingContentletThatDoesNotExist {
+        @Test
+        @DisplayName("it should save the contentlet")
+        void should_save_contentlet() {
+            verify(repository, times(1)).save(toCreate);
+        }
 
-            ContentletService.ResultPair result;
+        @Test
+        @DisplayName("it should assign a generated id")
+        void should_assign_a_generated_id() {
+            assertThat(created.getId()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("it should mark the contentlet as new")
+        void should_mark_the_contentlet_as_new() {
+            assertThat(created.isNew()).isTrue();
+        }
+    }
+
+    @NestedPerClass
+    @DisplayName("create given content that matches criteria for entity transformations")
+    class CreateWithTransformations {
+
+        ContentletRepository repository = Mockito.mock(ContentletRepository.class);
+        ContentletService contentletService;
+
+        ContentletEntity toCreate = new ContentletEntity(null,
+            Map.ofEntries(
+                entry("language", "en"),
+                entry("stName", "Blog"),
+                entry("parentDmsId", "parentDmsIdABCDE")));
+
+        @BeforeAll
+        void beforeAll() {
+            contentletService = newServiceWith(repository);
+
+            // When
+            contentletService.create(toCreate);
+        }
+
+        @Test
+        @DisplayName("it should apply transformations before saving")
+        void it_should_apply_transformations_before_saving() {
+
+            var argumentCaptor = ArgumentCaptor.forClass(ContentletEntity.class);
+            verify(repository).save(argumentCaptor.capture());
+
+            var savedValue = argumentCaptor.getValue();
+
+            // Some expected Transformations
+            assertThat(savedValue.getSchemalessData())
+                .hasEntrySatisfying("contentType", value -> assertThat(value).isEqualTo("Blog"));
+            assertThat(savedValue.getSchemalessData())
+                .hasEntrySatisfying("identifier", value -> assertThat(value).isEqualTo("parentDmsIdABCDE"));
+        }
+    }
+
+    @NestedPerClass
+    @DisplayName("update")
+    class Update {
+
+        @NestedPerClass
+        @DisplayName("when the contentlet exists")
+        class WhenContentletExists {
+
+            ContentletRepository repository = Mockito.mock(ContentletRepository.class);
+            ContentletService contentletService;
+
+            UUID id = UuidV7.generate();
+            ContentletEntity toUpdate = new ContentletEntity(id);
+            Optional<ContentletEntity> result;
 
             @BeforeAll
             void beforeAll() {
-                passthroughContentletRepository(repository); // because we reset the repository in afterAll
+                contentletService = newServiceWith(repository);
 
                 // Given
-                when(repository.existsById(any(UUID.class))).thenReturn(false);
+                when(repository.existsById(id)).thenReturn(true);
 
-                // when
-                result = contentletService.save(toSave);
-            }
-
-            @AfterAll
-            void afterAll() {
-                Mockito.reset(repository);
+                // When
+                result = contentletService.update(id, toUpdate);
             }
 
             @Test
-            @DisplayName("it should save contentlet")
+            @DisplayName("it should save the contentlet")
             void should_save_contentlet() {
-                verifyContentletSaved();
+                verify(repository, times(1)).save(toUpdate);
             }
 
             @Test
-            @DisplayName("it should return result pair containing saved contentlet")
-            void should_return_result_pair_with_saved_contentlet() {
-                assertSameContentletSaved(result.contentletEntity());
-            }
-
-            @Test
-            @DisplayName("it should return result pair with isNew=true")
-            void should_return_result_pair_with_isNew_true() {
-                assertThat(result.isNew()).isTrue();
+            @DisplayName("it should return the updated contentlet")
+            void should_return_the_updated_contentlet() {
+                assertThat(result).isPresent();
+                assertThat(result.get().getId()).isEqualTo(id);
             }
         }
 
         @NestedPerClass
-        @DisplayName("when saving contentlet that does exist")
-        class SavingContentletThatDoesExist {
+        @DisplayName("when the contentlet does not exist")
+        class WhenContentletDoesNotExist {
 
-            ContentletService.ResultPair result;
+            ContentletRepository repository = Mockito.mock(ContentletRepository.class);
+            ContentletService contentletService;
+
+            UUID id = UuidV7.generate();
+            Optional<ContentletEntity> result;
+
             @BeforeAll
             void beforeAll() {
-
-                passthroughContentletRepository(repository); // because we reset the repository in afterAll
+                contentletService = newServiceWith(repository);
 
                 // Given
-                when(repository.existsById(any(UUID.class))).thenReturn(true);
+                when(repository.existsById(id)).thenReturn(false);
 
-                result = contentletService.save(toSave);
-            }
-
-            @AfterAll
-            void afterAll() {
-                Mockito.reset(repository);
+                // When
+                result = contentletService.update(id, new ContentletEntity(id));
             }
 
             @Test
-            @DisplayName("it should save contentlet")
-            void should_save_contentlet() {
-                verifyContentletSaved();
+            @DisplayName("it should return an empty result")
+            void should_return_empty_result() {
+                assertThat(result).isEmpty();
             }
 
             @Test
-            @DisplayName("it should return result pair containing saved contentlet")
-            void should_return_result_pair_with_saved_contentlet_and_isNew_false() {
-                assertSameContentletSaved(result.contentletEntity());
-            }
-
-            @Test
-            @DisplayName("it should return result pair with isNew=false")
-            void should_return_result_pair_with_isNew_false() {
-                assertThat(result.isNew()).isFalse();
-            }
-        }
-
-        @NestedPerClass
-        @DisplayName("Given content that matches criteria for entity transformations")
-        class SavingContentletWithTransformations {
-
-            ContentletEntity toSave = new ContentletEntity(UuidV7.generate(),
-                Map.ofEntries(
-                    entry("language", "en"),
-                    entry("stName", "Blog"),
-                    entry("parentDmsId", "parentDmsIdABCDE")));
-
-            @BeforeAll
-            void beforeAll() {
-
-                passthroughContentletRepository(repository); // because sibling classes reset the repository in their afterAll
-
-                when(repository.existsById(any(UUID.class))).thenReturn(false);
-            }
-
-            @NestedPerClass
-            @DisplayName("when saving contentlet")
-            class WhenSavingContentlet {
-
-                @BeforeAll
-                void beforeAll() {
-                    contentletService.save(toSave);
-                }
-
-                @Test()
-                @DisplayName("it should apply transformations before saving")
-                void it_should_apply_transformations_before_saving() {
-
-                    var argumentCaptor = ArgumentCaptor.forClass(ContentletEntity.class);
-                    verify(repository).save(argumentCaptor.capture());
-
-                    var savedValue = argumentCaptor.getValue();
-
-                    // Some expected Transformations
-                    assertThat(savedValue.getSchemalessData())
-                        .hasEntrySatisfying("contentType", value -> assertThat(value).isEqualTo("Blog"));
-                    assertThat(savedValue.getSchemalessData())
-                        .hasEntrySatisfying("identifier", value -> assertThat(value).isEqualTo("parentDmsIdABCDE"));
-
-                }
+            @DisplayName("it should not save anything")
+            void should_not_save_anything() {
+                verify(repository, never()).save(any());
             }
         }
     }

--- a/src/test/java/com/contented/contented/contentlet/elasticsearch/SearchControllerTests.java
+++ b/src/test/java/com/contented/contented/contentlet/elasticsearch/SearchControllerTests.java
@@ -3,7 +3,6 @@ package com.contented.contented.contentlet.elasticsearch;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import com.contented.contented.contentlet.AbstractContentletControllerTests;
 import com.contented.contented.contentlet.ContentletEntity;
-import com.contented.contented.contentlet.UuidV7;
 import com.contented.contented.contentlet.testutils.NestedPerClass;
 import tools.jackson.databind.annotation.JsonDeserialize;
 import org.junit.jupiter.api.*;
@@ -21,6 +20,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.List;
+import java.util.UUID;
 
 import static com.contented.contented.contentlet.testutils.ElasticSearchContainerUtils.elasticsearchContainer;
 import static com.contented.contented.contentlet.testutils.ElasticSearchContainerUtils.startAndRegisterElasticsearchContainer;
@@ -83,16 +83,21 @@ public class SearchControllerTests {
 
             record SomeContent(String id, String contentType, String someOtherField){}
 
-            final SomeContent savedContent = new SomeContent(UuidV7.generate().toString(), "Blog", "Some field value");
+            // Given a body with no id (ids are server-assigned)
+            final SomeContent savedContent = new SomeContent(null, "Blog", "Some field value");
+
+            UUID createdId;
 
             @BeforeAll
             void given() {
 
                 // Could use rest endpoint, or could go directly to service
-                contentletEndpointClient.put().bodyValue(savedContent)
-                    .exchange().expectStatus().is2xxSuccessful();
+                createdId = contentletEndpointClient.post().bodyValue(savedContent)
+                    .exchange().expectStatus().isCreated()
+                    .expectBody(ContentletEntity.class)
+                    .returnResult().getResponseBody().getId();
 
-                waitForESDocumentCount(elasticsearchOperations, indexCoordinates, savedContent.id(), 1);
+                waitForESDocumentCount(elasticsearchOperations, indexCoordinates, createdId.toString(), 1);
             }
 
 
@@ -121,7 +126,7 @@ public class SearchControllerTests {
 
                 @BeforeAll
                 void when() {
-                    var queryString = String.format(queryForContentTemplate, savedContent.id());
+                    var queryString = String.format(queryForContentTemplate, createdId.toString());
                     response = searchEndpointClient.post().uri("/withcontent").bodyValue(queryString).exchange();
 
                     // Calling `expectBody` multiple times has inconsistent results so just do it once.
@@ -160,7 +165,7 @@ public class SearchControllerTests {
                             .value(value -> {
                                 var contentlets = value.contentlets();
                                 assertThat(contentlets).hasSize(1);
-                                assertThat(contentlets.get(0).getId().toString()).isEqualTo(savedContent.id());
+                                assertThat(contentlets.get(0).getId().toString()).isEqualTo(createdId.toString());
                             });
                 }
 

--- a/src/test/java/com/contented/contented/contentlet/elasticsearch/transformation/BlogTransformerTest.java
+++ b/src/test/java/com/contented/contented/contentlet/elasticsearch/transformation/BlogTransformerTest.java
@@ -35,7 +35,7 @@ class BlogTransformerTest {
                     .transform(
                             new ContentletEntity(UuidV7.generate(),
                                     Map.ofEntries(
-                                            entry("stName", "Blog"),
+                                            entry("contentType", "Blog"),
                                             entry("title", "Blog Title"),
                                             entry("body", "Blog Body"),
                                             entry("language", "en")

--- a/src/test/java/com/contented/contented/contentlet/transformation/StandardDMSContentTransformerTest.java
+++ b/src/test/java/com/contented/contented/contentlet/transformation/StandardDMSContentTransformerTest.java
@@ -17,54 +17,32 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("StandardDMSContentTransformer")
 class StandardDMSContentTransformerTest {
 
+    Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
+
+    StandardDMSContentTransformer transformer = new StandardDMSContentTransformer(clock);
+
     @NestedPerClass
     @DisplayName("transform")
     class TransformTests {
-
-        Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
-
-        StandardDMSContentTransformer transformer = new StandardDMSContentTransformer(clock);
 
         @NestedPerClass
         @DisplayName("Given a contentletEntity with no id")
         class GivenContentletWithNoId {
 
             ContentletEntity contentletEntity = new ContentletEntity(null,
-                Map.ofEntries(entry("language", "en"),
-                    entry("dmsId", "dmsid1234"),
-                    entry("parentDmsId", "parentdmsid1234"),
-                    entry("stName", "Blog")
+                Map.ofEntries(entry("language", "EN"),
+                    entry("contentType", "Blog")
                 )
             );
 
             @Test
-            @DisplayName("it should populate the `inode` from the `dmsId`")
-            void it_should_populate_inode_from_dmsId() {
+            @DisplayName("it should normalize the `language` to lowercase")
+            void it_should_normalize_language_to_lowercase() {
                 // When
                 var result = transformer.transform(contentletEntity);
 
                 // Then
-                assertThat((String) result.get("inode")).isEqualTo(contentletEntity.get("dmsId"));
-            }
-
-            @Test
-            @DisplayName("it should populate the `identifier` from the `parentDmsId`")
-            void it_should_populate_identifier_from_parentDmsId() {
-                // When
-                var result = transformer.transform(contentletEntity);
-
-                // Then
-                assertThat((String) result.get("identifier")).isEqualTo(contentletEntity.get("parentDmsId"));
-            }
-
-            @Test
-            @DisplayName("it should populate the `contentType` from the `stName`")
-            void it_should_populate_contentType_from_stName() {
-                // When
-                var result = transformer.transform(contentletEntity);
-
-                // Then
-                assertThat((String) result.get("contentType")).isEqualTo(contentletEntity.get("stName"));
+                assertThat((String) result.get("language")).isEqualTo("en");
             }
 
             @Test
@@ -94,21 +72,39 @@ class StandardDMSContentTransformerTest {
 
             ContentletEntity toSave = new ContentletEntity(UuidV7.generate(), Map.ofEntries(
                 entry("language", "en"),
-                entry("dmsId", "dmsid1234"),
-                entry("inode", "inode1234"),
-                entry("parentDmsId", "parentdmsid1234"),
-                entry("stName", "Blog")
+                entry("contentType", "Blog")
             ));
 
             @Test
-            @DisplayName("it should not override the id with the dmsId or inode")
-            void it_should_not_override_the_id_with_the_dmsId_or_inode() {
+            @DisplayName("it should preserve the id")
+            void it_should_preserve_the_id() {
                 // When
                 var result = transformer.transform(toSave);
 
                 // Then
                 assertThat(result.getId()).isEqualTo(toSave.getId());
             }
+        }
+    }
+
+    @NestedPerClass
+    @DisplayName("test")
+    class TestPredicate {
+
+        @Test
+        @DisplayName("it should match a contentlet whose contentType is supported")
+        void it_should_match_supported_content_type() {
+            var contentletEntity = new ContentletEntity(null, Map.of("contentType", "Blog"));
+
+            assertThat(transformer.test(contentletEntity)).isTrue();
+        }
+
+        @Test
+        @DisplayName("it should not match a contentlet whose contentType is unsupported")
+        void it_should_not_match_unsupported_content_type() {
+            var contentletEntity = new ContentletEntity(null, Map.of("contentType", "SomethingElse"));
+
+            assertThat(transformer.test(contentletEntity)).isFalse();
         }
     }
 }


### PR DESCRIPTION
## Summary

Moves the contentlet write API to **intrinsic (server-generated) ids** and strips the legacy DMS baggage from the inbound transformer.

### 1. POST create + PUT update split

Replaces the old collection-level `PUT /contentlets` upsert with a conformant create/update pair:

- **`POST /contentlets`** — create. A client-supplied body id is rejected with `400`; otherwise a UUIDv7 is generated and the response is `201 Created` with a `Location: /contentlets/{id}` header.
- **`PUT /contentlets/{id}`** — update only. The URL id is authoritative; a body id that disagrees with it returns `400`, and an unknown id returns `404` (create-on-missing is deliberately disabled — creation is POST-only).

`ContentletService.save`/`ResultPair` are replaced by `create()` and `update()`: `create` always assigns a UUIDv7 and marks the entity new; `update` checks `existsById` first and returns empty (→ `404`) when absent.

`CLAUDE.md` is also refreshed — it was stale after the Postgres migration (MongoDB references, the old `PUT` dual-write flow, `MongoDBContainerUtils`) and now describes the POST/PUT split.

### 2. Strip legacy DMS fields from StandardDMSContentTransformer

Drops the `inode`/`dmsId`, `identifier`/`parentDmsId`, `stName`, and `live` legacy support fields and the derivations that populated them. The transformer now only normalizes `language` to lowercase and stamps `modDate`, gated by a `contentType` match (`stName` is no longer consulted). The ES-side `identifier` (derived from `id + language` in `StandardContentletTransformations`) is a separate concept and is untouched.

## Test plan

- Migrated all `PUT`-with-body-id tests to the new shape; controller tests now cover create (201 + Location), create-with-id (400), update (200), update-unknown (404), and mismatched-body-id (400). Tests that relied on knowing the id up front now POST without an id and capture the generated id from the response.
- Tests that fed the transformer legacy fields now use `contentType`; `StandardDMSContentTransformerTest` rewritten to cover language normalization, modDate, id preservation, and the `contentType` predicate.
- `./mvnw test` for the affected classes: **all passing, 0 failures**.

## Follow-ups (deferred, not in this PR)

- Replace `Persistable` + `isNew` with a `@Version` field — removes the manual new-vs-existing flag and adds optimistic locking (needs a Liquibase migration).
- Optional `Idempotency-Key` on POST and an extrinsic natural-key path for idempotent re-ingest.