### PR TITLE
feat: Return RFC 9457 problem detail bodies for API errors

### DIFF
--- a/src/main/java/com/contented/contented/contentlet/ContentletController.java
+++ b/src/main/java/com/contented/contented/contentlet/ContentletController.java
@@ -34,7 +34,7 @@ public class ContentletController {
     ResponseEntity<ContentletEntity> findById(@PathVariable UUID id) {
         return contentletService.findById(id)
                 .map(contentletEntity -> ResponseEntity.ok(contentletEntity))
-                .orElseGet(() -> ResponseEntity.notFound().build());
+                .orElseThrow(() -> new ContentletNotFoundException(id));
     }
 
     @PostMapping
@@ -42,7 +42,8 @@ public class ContentletController {
                                                       UriComponentsBuilder uriBuilder) {
         // Ids are server-assigned; a client must not supply one when creating.
         if (contentletDTO.getId() != null) {
-            return ResponseEntity.badRequest().build();
+            throw new InvalidContentletException(
+                    "A contentlet id must not be supplied when creating; ids are server-assigned.");
         }
         ContentletEntity toSave = new ContentletEntity(null, contentletDTO.get());
 
@@ -58,13 +59,14 @@ public class ContentletController {
                                                       @RequestBody ContentletDTO contentletDTO) {
         // The URL is the source of truth for identity; a body id must agree with it.
         if (contentletDTO.getId() != null && !contentletDTO.getId().equals(id)) {
-            return ResponseEntity.badRequest().build();
+            throw new InvalidContentletException(
+                    "The body id `" + contentletDTO.getId() + "` does not match the URL id `" + id + "`.");
         }
         ContentletEntity toSave = new ContentletEntity(id, contentletDTO.get());
 
         return contentletService.update(id, toSave)
                 .map(updated -> ResponseEntity.ok(updated))
-                .orElseGet(() -> ResponseEntity.notFound().build());
+                .orElseThrow(() -> new ContentletNotFoundException(id));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/contented/contented/contentlet/ContentletExceptionHandler.java
+++ b/src/main/java/com/contented/contented/contentlet/ContentletExceptionHandler.java
@@ -1,0 +1,26 @@
+package com.contented.contented.contentlet;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class ContentletExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(ContentletNotFoundException.class)
+    ProblemDetail handleNotFound(ContentletNotFoundException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, ex.getMessage());
+        problem.setTitle("Contentlet not found");
+        problem.setProperty("contentletId", ex.getId().toString());
+        return problem;
+    }
+
+    @ExceptionHandler(InvalidContentletException.class)
+    ProblemDetail handleInvalid(InvalidContentletException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
+        problem.setTitle("Invalid contentlet request");
+        return problem;
+    }
+}

--- a/src/main/java/com/contented/contented/contentlet/ContentletNotFoundException.java
+++ b/src/main/java/com/contented/contented/contentlet/ContentletNotFoundException.java
@@ -1,0 +1,17 @@
+package com.contented.contented.contentlet;
+
+import java.util.UUID;
+
+public class ContentletNotFoundException extends RuntimeException {
+
+    private final UUID id;
+
+    public ContentletNotFoundException(UUID id) {
+        super("Contentlet `" + id + "` was not found");
+        this.id = id;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+}

--- a/src/main/java/com/contented/contented/contentlet/InvalidContentletException.java
+++ b/src/main/java/com/contented/contented/contentlet/InvalidContentletException.java
@@ -1,0 +1,8 @@
+package com.contented.contented.contentlet;
+
+public class InvalidContentletException extends RuntimeException {
+
+    public InvalidContentletException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,6 +6,9 @@ elasticsearch:
     mappingsfile: "elasticsearch/mappings.json"
 
 spring:
+  mvc:
+    problemdetails:
+      enabled: true
   threads:
     virtual:
       enabled: true

--- a/src/test/java/com/contented/contented/contentlet/ContentletControllerBasicTests.java
+++ b/src/test/java/com/contented/contented/contentlet/ContentletControllerBasicTests.java
@@ -6,6 +6,7 @@ import com.contented.contented.contentlet.testutils.StubbingUtils;
 import org.junit.jupiter.api.*;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -125,6 +126,15 @@ public class ContentletControllerBasicTests extends AbstractContentletController
             void should_return_a_400() {
                 response.expectStatus().isBadRequest();
             }
+
+            @Test
+            @DisplayName("it should return a problem detail body")
+            void should_return_a_problem_detail_body() {
+                response.expectHeader().contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                        .expectBody()
+                        .jsonPath("$.status").isEqualTo(400)
+                        .jsonPath("$.detail").exists();
+            }
         }
     }
 
@@ -195,6 +205,15 @@ public class ContentletControllerBasicTests extends AbstractContentletController
             void should_return_a_404() {
                 response.expectStatus().isNotFound();
             }
+
+            @Test
+            @DisplayName("it should return a problem detail body")
+            void should_return_a_problem_detail_body() {
+                response.expectHeader().contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                        .expectBody()
+                        .jsonPath("$.status").isEqualTo(404)
+                        .jsonPath("$.detail").exists();
+            }
         }
 
         @NestedPerClass
@@ -218,6 +237,15 @@ public class ContentletControllerBasicTests extends AbstractContentletController
             @DisplayName("it should return a 400 BAD REQUEST status code")
             void should_return_a_400() {
                 response.expectStatus().isBadRequest();
+            }
+
+            @Test
+            @DisplayName("it should return a problem detail body")
+            void should_return_a_problem_detail_body() {
+                response.expectHeader().contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                        .expectBody()
+                        .jsonPath("$.status").isEqualTo(400)
+                        .jsonPath("$.detail").exists();
             }
         }
     }


### PR DESCRIPTION
Error responses from the contentlet API previously carried an empty body. Introduce a @RestControllerAdvice that maps domain exceptions to ProblemDetail and switch the controller to throw instead of returning bare badRequest()/notFound() responses:

- ContentletNotFoundException -> 404 (with a contentletId member)
- InvalidContentletException -> 400

Enable spring.mvc.problemdetails.enabled so framework-level errors (malformed JSON, non-UUID path id, wrong method) render as problem details too, giving every error a uniform application/problem+json body.