### PR TITLE
feat: Promote contentType to a first-class, required, immutable field

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,15 +27,17 @@ Ids are **intrinsic** (server-generated UUIDv7, assigned in `ContentletService`)
 - `POST /contentlets` (`ContentletController.createContentlet` → `ContentletService.create`) — create. A client-supplied body id is rejected with `400`; otherwise a UUIDv7 is generated and the response is `201 Created` with a `Location` header.
 - `PUT /contentlets/{id}` (`ContentletController.updateContentlet` → `ContentletService.update`) — update only. The URL id is authoritative; a body id that disagrees with it is rejected with `400`, and an unknown id returns `404` (create-on-missing is deliberately disabled — creation is POST-only).
 
+`contentType` is required on both writes — a create or update with a blank `contentType` is rejected with `400` — and is **immutable**: an update whose `contentType` differs from the stored one is rejected with `400`. All `400`/`404` responses carry an RFC 9457 `application/problem+json` body (`ContentletExceptionHandler` maps `InvalidContentletException`/`ContentletNotFoundException` to `ProblemDetail`).
+
 Both then run the same pipeline:
 
-1. **Inbound transformation** — `TransformationHandler` runs the entity through the *first* `ContentletEntityTransformer` bean whose `test()` predicate matches (e.g. `StandardDMSContentTransformer`, which normalizes fields like `stName`/`contentType`/`identifier` and stamps `modDate`). No match = entity passes through unchanged.
-2. **Postgres save** — `ContentletRepository` (Spring Data JDBC `ListCrudRepository`). `ContentletEntity` implements `Persistable<UUID>` and carries a `@Transient isNew` flag that drives the INSERT-vs-UPDATE choice for assigned ids: `create` sets it `true`, `update` checks `existsById` first (absent → `404`, no save) and sets it `false`.
+1. **Inbound transformation** — `TransformationHandler` runs the entity through the *first* `ContentletEntityTransformer` bean whose `test()` predicate matches (e.g. `StandardDMSContentTransformer`, which normalizes `language` and stamps `modDate`; it gates on `contentType`). No match = entity passes through unchanged.
+2. **Postgres save** — `ContentletRepository` (Spring Data JDBC `ListCrudRepository`). `ContentletEntity` implements `Persistable<UUID>` and carries a `@Transient isNew` flag that drives the INSERT-vs-UPDATE choice for assigned ids: `create` sets it `true`, `update` loads the current row first (absent → `404`, no save; also the source of the immutable-contentType check) and sets it `false`.
 3. **Elasticsearch indexing** — `ContentletIndexer` picks the *first* matching `ESRecordTransformer` bean (e.g. `BlogTransformer`), which maps one contentlet to **one or more** `EntityAsMap` ES documents. No match = warning logged, nothing indexed (the Postgres save still succeeds).
 
 Both transformer families are discovered by Spring `List<T>` injection of `@Component` beans and gated by `Predicate.test()` — to support a new content type, add a new transformer bean of either kind; no registration step exists.
 
-`ContentletEntity` is schemaless: an `@Id` plus a `Map<String, Object>` exposed through Jackson's `@JsonAnySetter`/`@JsonAnyGetter`, so arbitrary JSON fields round-trip through the API and Postgres.
+`ContentletEntity` is mostly schemaless: an `@Id` and a first-class `contentType` (its own `content_type` column), plus a `Map<String, Object>` of everything else exposed through Jackson's `@JsonAnySetter`/`@JsonAnyGetter`, so arbitrary JSON fields round-trip through the API and Postgres. `contentType` is an explicit field only — it's passed to the `(id, contentType, map)` constructor, never read out of the map (on the JSON path a declared property already wins over the any-setter). The no-arg constructor exists for Jackson deserialization; Spring Data uses the `@PersistenceCreator` constructor.
 
 Other entry points:
 - `POST /search/withcontent` (`SearchController`) — accepts a raw Elasticsearch query JSON body, runs it against the index, then hydrates full contentlets from Postgres by the ids found in the hits (`SearchResultsWithContent` carries both; it has custom Jackson serializers in the `elasticsearch` package).

--- a/src/main/java/com/contented/contented/contentlet/ContentletController.java
+++ b/src/main/java/com/contented/contented/contentlet/ContentletController.java
@@ -45,7 +45,7 @@ public class ContentletController {
             throw new InvalidContentletException(
                     "A contentlet id must not be supplied when creating; ids are server-assigned.");
         }
-        ContentletEntity toSave = new ContentletEntity(null, contentletDTO.get());
+        ContentletEntity toSave = new ContentletEntity(null, contentletDTO.getContentType(), contentletDTO.get());
 
         var created = contentletService.create(toSave);
         var location = uriBuilder.path("/{base}/{id}")
@@ -62,7 +62,7 @@ public class ContentletController {
             throw new InvalidContentletException(
                     "The body id `" + contentletDTO.getId() + "` does not match the URL id `" + id + "`.");
         }
-        ContentletEntity toSave = new ContentletEntity(id, contentletDTO.get());
+        ContentletEntity toSave = new ContentletEntity(id, contentletDTO.getContentType(), contentletDTO.get());
 
         return contentletService.update(id, toSave)
                 .map(updated -> ResponseEntity.ok(updated))

--- a/src/main/java/com/contented/contented/contentlet/ContentletDTO.java
+++ b/src/main/java/com/contented/contented/contentlet/ContentletDTO.java
@@ -20,11 +20,13 @@ public class ContentletDTO {
 
     private UUID id;
 
+    private String contentType;
+
     @JsonIgnore
     private Map<String, Object> schemalessData = new LinkedHashMap<>();
 
     public ContentletDTO(UUID id) {
-        this(id, new LinkedHashMap<>());
+        this(id, null, new LinkedHashMap<>());
     }
     @JsonAnySetter
     public void add(String key, Object value) {

--- a/src/main/java/com/contented/contented/contentlet/ContentletEntity.java
+++ b/src/main/java/com/contented/contented/contentlet/ContentletEntity.java
@@ -16,36 +16,43 @@ import java.util.UUID;
 @Table("contentlet")
 public class ContentletEntity implements Persistable<UUID> {
 
+    public static final String CONTENT_TYPE_FIELD = "contentType";
+
     @Id
     private UUID id;
+
+    private String contentType;
 
     @JsonIgnore
     private SchemalessData data;
 
     // Drives Spring Data JDBC's INSERT-vs-UPDATE choice for our assigned (non-generated) ids;
-    // set from the existsById check in ContentletService.
+    // create sets it true, update sets it false, and a DB-loaded row is constructed as not-new.
     @Transient
     @JsonIgnore
     private boolean isNew = true;
 
-    public ContentletEntity() {
-        this.data = new SchemalessData();
-    }
-
-    public ContentletEntity(UUID id) {
-        this(id, new LinkedHashMap<>());
-    }
-
-    public ContentletEntity(UUID id, Map<String, Object> schemalessData) {
+    private ContentletEntity(UUID id, String contentType, SchemalessData data, boolean isNew) {
         this.id = id;
-        this.data = new SchemalessData(new LinkedHashMap<>(schemalessData));
-    }
-
-    @PersistenceCreator
-    ContentletEntity(UUID id, SchemalessData data) {
-        this.id = id;
+        this.contentType = contentType;
         this.data = data;
-        this.isNew = false;
+        this.isNew = isNew;
+    }
+
+    // Required by Jackson to deserialize a contentlet from JSON: id/contentType land via their
+    // setters, everything else via @JsonAnySetter. (Spring Data uses the @PersistenceCreator factory.)
+    public ContentletEntity() {
+        this(null, null, new SchemalessData(), true);
+    }
+
+    public ContentletEntity(UUID id, String contentType, Map<String, Object> schemalessData) {
+        this(id, contentType, new SchemalessData(new LinkedHashMap<>(schemalessData)), true);
+    }
+
+    // Spring Data instantiates loaded rows here; an existing row is by definition not new.
+    @PersistenceCreator
+    static ContentletEntity fromDatabase(UUID id, String contentType, SchemalessData data) {
+        return new ContentletEntity(id, contentType, data, false);
     }
 
     public UUID getId() {
@@ -54,6 +61,14 @@ public class ContentletEntity implements Persistable<UUID> {
 
     public void setId(UUID id) {
         this.id = id;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
     }
 
     @Override

--- a/src/main/java/com/contented/contented/contentlet/ContentletService.java
+++ b/src/main/java/com/contented/contented/contentlet/ContentletService.java
@@ -2,6 +2,7 @@ package com.contented.contented.contentlet;
 
 import com.contented.contented.contentlet.elasticsearch.ContentletIndexer;
 import lombok.extern.log4j.Log4j2;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.elasticsearch.client.elc.EntityAsMap;
 import org.springframework.stereotype.Service;
 
@@ -27,6 +28,7 @@ public class ContentletService {
     }
 
     public ContentletEntity create(ContentletEntity contentletEntity) {
+        requireContentType(contentletEntity);
         var toSave = transformationHandler.applyTransformation(contentletEntity);
         toSave.setId(UuidV7.generate());
         toSave.setNew(true);
@@ -37,17 +39,33 @@ public class ContentletService {
     }
 
     public Optional<ContentletEntity> update(UUID id, ContentletEntity contentletEntity) {
-        if (!contentletRepository.existsById(id)) {
+        requireContentType(contentletEntity);
+        var existing = contentletRepository.findById(id);
+        if (existing.isEmpty()) {
             log.info("Contentlet `{}` not found; nothing to update", id);
             return Optional.empty();
         }
+        // A contentlet's contentType is fixed at creation.
+        if (!existing.get().getContentType().equalsIgnoreCase(contentletEntity.getContentType())) {
+            throw new InvalidContentletException(
+                "A contentlet's contentType cannot be changed; `" + existing.get().getContentType()
+                    + "` was created, `" + contentletEntity.getContentType() + "` was supplied.");
+        }
         var toSave = transformationHandler.applyTransformation(contentletEntity);
         toSave.setId(id);
+        // Preserve the stored contentType so its casing never drifts on update.
+        toSave.setContentType(existing.get().getContentType());
         toSave.setNew(false);
         var saved = contentletRepository.save(toSave);
         log.info("Updated contentlet: `{}` successfully", saved.getId());
         saveToES(saved);
         return Optional.of(saved);
+    }
+
+    private void requireContentType(ContentletEntity contentletEntity) {
+        if (StringUtils.isBlank(contentletEntity.getContentType())) {
+            throw new InvalidContentletException("A contentlet must have a contentType.");
+        }
     }
 
     private List<EntityAsMap> saveToES(ContentletEntity contentletEntity) {

--- a/src/main/java/com/contented/contented/contentlet/elasticsearch/transformation/BlogTransformer.java
+++ b/src/main/java/com/contented/contented/contentlet/elasticsearch/transformation/BlogTransformer.java
@@ -9,7 +9,6 @@ import java.util.List;
 
 import static com.contented.contented.contentlet.elasticsearch.transformation.StandardContentletTransformations.applyStandardTransformations;
 import static com.contented.contented.contentlet.transformation.StandardDMSContentTransformer.BLOG_VALUE;
-import static com.contented.contented.contentlet.transformation.StandardDMSContentTransformer.CONTENT_TYPE_FIELD;
 
 @Component
 public class BlogTransformer implements ESRecordTransformer {
@@ -25,6 +24,6 @@ public class BlogTransformer implements ESRecordTransformer {
 
     @Override
     public boolean test(ContentletEntity contentletEntity) {
-        return BLOG_VALUE.equals(contentletEntity.getSchemalessData().get(CONTENT_TYPE_FIELD));
+        return BLOG_VALUE.equalsIgnoreCase(contentletEntity.getContentType());
     }
 }

--- a/src/main/java/com/contented/contented/contentlet/elasticsearch/transformation/StandardContentletTransformations.java
+++ b/src/main/java/com/contented/contented/contentlet/elasticsearch/transformation/StandardContentletTransformations.java
@@ -7,7 +7,7 @@ import org.springframework.data.elasticsearch.client.elc.EntityAsMap;
 public class StandardContentletTransformations {
 
     public static EntityAsMap applyStandardTransformations(ContentletEntity toTransform, EntityAsMap toApplyTo) {
-        toApplyTo.put("contentType", StringUtils.lowerCase(toTransform.get("contentType")));
+        toApplyTo.put(ContentletEntity.CONTENT_TYPE_FIELD, StringUtils.lowerCase(toTransform.getContentType()));
         toApplyTo.put("language", toTransform.get("language"));
         toApplyTo.put("identifier", toTransform.getId() + "_" + toTransform.get("language"));
         toApplyTo.put("id", toTransform.getId().toString());

--- a/src/main/java/com/contented/contented/contentlet/transformation/StandardDMSContentTransformer.java
+++ b/src/main/java/com/contented/contented/contentlet/transformation/StandardDMSContentTransformer.java
@@ -13,8 +13,6 @@ import java.util.Map;
 @Component
 public class StandardDMSContentTransformer implements ContentletEntityTransformer {
 
-    public static final String CONTENT_TYPE_FIELD = "contentType";
-
     public static final String LANGUAGE_FIELD = "language";
 
     public static final String MODE_DATE_FIELD = "modDate";
@@ -35,7 +33,8 @@ public class StandardDMSContentTransformer implements ContentletEntityTransforme
         Map<String, Object> mutableSchemalessData = new HashMap<>(toTransform.getSchemalessData());
         normalizeLanguage(mutableSchemalessData);
         setModDate(mutableSchemalessData);
-        return new ContentletEntity(toTransform.getId(), Collections.unmodifiableMap(mutableSchemalessData));
+        return new ContentletEntity(toTransform.getId(), toTransform.getContentType(),
+                Collections.unmodifiableMap(mutableSchemalessData));
     }
 
     private void setModDate(Map<String, Object> mutableSchemalessData) {
@@ -55,7 +54,7 @@ public class StandardDMSContentTransformer implements ContentletEntityTransforme
 
     @Override
     public boolean test(ContentletEntity contentletEntity) {
-        String contentType = (String) contentletEntity.getSchemalessData().get(CONTENT_TYPE_FIELD);
+        String contentType = contentletEntity.getContentType();
         return SUPPORTED_TYPES.stream()
                 .anyMatch(type -> type.equalsIgnoreCase(contentType));
     }

--- a/src/main/resources/db/changelog/changes/002-add-content-type.sql
+++ b/src/main/resources/db/changelog/changes/002-add-content-type.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+
+--changeset contented:002-add-content-type
+ALTER TABLE contentlet ADD COLUMN content_type text;
+UPDATE contentlet SET content_type = data ->> 'contentType';
+UPDATE contentlet SET data = data - 'contentType';
+ALTER TABLE contentlet ALTER COLUMN content_type SET NOT NULL;
+--rollback ALTER TABLE contentlet DROP COLUMN content_type;

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2,3 +2,6 @@ databaseChangeLog:
   - include:
       file: changes/001-create-contentlet.sql
       relativeToChangelogFile: true
+  - include:
+      file: changes/002-add-content-type.sql
+      relativeToChangelogFile: true

--- a/src/test/java/com/contented/contented/contentlet/ContentletControllerBasicTests.java
+++ b/src/test/java/com/contented/contented/contentlet/ContentletControllerBasicTests.java
@@ -13,6 +13,7 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.reactive.server.EntityExchangeResult;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
+import java.util.Map;
 import java.util.UUID;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -43,7 +44,7 @@ public class ContentletControllerBasicTests extends AbstractContentletController
     }
 
     ContentletEntity saveOneContentlet() {
-        return contentletRepository.save(new ContentletEntity(UuidV7.generate()));
+        return contentletRepository.save(new ContentletEntity(UuidV7.generate(), "SomeType", Map.of()));
     }
 
     void mockContentletIndexer() {
@@ -69,6 +70,7 @@ public class ContentletControllerBasicTests extends AbstractContentletController
             @BeforeAll()
             void beforeAll() {
                 mockContentletIndexer();
+                toCreate.setContentType("SomeType");
                 toCreate.add("field1", "value1");
 
                 // When
@@ -136,6 +138,40 @@ public class ContentletControllerBasicTests extends AbstractContentletController
                         .jsonPath("$.detail").exists();
             }
         }
+
+        @NestedPerClass
+        @DisplayName("when creating a contentlet with no contentType")
+        class CreateWithoutContentType {
+
+            // Given a body with no contentType
+            ContentletDTO toCreate = new ContentletDTO();
+
+            WebTestClient.ResponseSpec response;
+
+            @BeforeAll()
+            void beforeAll() {
+                mockContentletIndexer();
+                toCreate.add("field1", "value1");
+
+                // When
+                response = contentletEndpointClient.post().bodyValue(toCreate).exchange();
+            }
+
+            @Test
+            @DisplayName("it should return a 400 BAD REQUEST status code")
+            void should_return_a_400() {
+                response.expectStatus().isBadRequest();
+            }
+
+            @Test
+            @DisplayName("it should return a problem detail body")
+            void should_return_a_problem_detail_body() {
+                response.expectHeader().contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                        .expectBody()
+                        .jsonPath("$.status").isEqualTo(400)
+                        .jsonPath("$.detail").exists();
+            }
+        }
     }
 
     @Nested
@@ -147,7 +183,7 @@ public class ContentletControllerBasicTests extends AbstractContentletController
         class UpdateExistingContentlet {
 
             // Given an existing contentlet
-            ContentletEntity existing = new ContentletEntity(UuidV7.generate());
+            ContentletEntity existing = new ContentletEntity(UuidV7.generate(), "SomeType", Map.of());
 
             WebTestClient.ResponseSpec response;
 
@@ -157,6 +193,7 @@ public class ContentletControllerBasicTests extends AbstractContentletController
                 contentletRepository.save(existing);
 
                 ContentletDTO update = new ContentletDTO(existing.getId());
+                update.setContentType("SomeType");
                 update.add("field1", "updatedValue");
 
                 // When
@@ -193,10 +230,14 @@ public class ContentletControllerBasicTests extends AbstractContentletController
                 mockContentletIndexer();
                 UUID id = UuidV7.generate();
 
+                // A valid body so this exercises the not-found path, not contentType validation
+                ContentletDTO update = new ContentletDTO(id);
+                update.setContentType("SomeType");
+
                 // When
                 response = contentletEndpointClient.put()
                         .uri("/{id}", id)
-                        .bodyValue(new ContentletDTO(id))
+                        .bodyValue(update)
                         .exchange();
             }
 
@@ -248,6 +289,46 @@ public class ContentletControllerBasicTests extends AbstractContentletController
                         .jsonPath("$.detail").exists();
             }
         }
+
+        @NestedPerClass
+        @DisplayName("when changing the contentType of an existing contentlet")
+        class UpdateChangingContentType {
+
+            // Given an existing contentlet whose contentType is "Blog"
+            ContentletEntity existing = new ContentletEntity(UuidV7.generate(), "Blog", Map.of());
+
+            WebTestClient.ResponseSpec response;
+
+            @BeforeAll()
+            void beforeAll() {
+                mockContentletIndexer();
+                contentletRepository.save(existing);
+
+                ContentletDTO update = new ContentletDTO(existing.getId());
+                update.setContentType("News");
+
+                // When the update supplies a different contentType
+                response = contentletEndpointClient.put()
+                        .uri("/{id}", existing.getId())
+                        .bodyValue(update)
+                        .exchange();
+            }
+
+            @Test
+            @DisplayName("it should return a 400 BAD REQUEST status code")
+            void should_return_a_400() {
+                response.expectStatus().isBadRequest();
+            }
+
+            @Test
+            @DisplayName("it should return a problem detail body")
+            void should_return_a_problem_detail_body() {
+                response.expectHeader().contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                        .expectBody()
+                        .jsonPath("$.status").isEqualTo(400)
+                        .jsonPath("$.detail").exists();
+            }
+        }
     }
 
     @Nested
@@ -275,7 +356,7 @@ public class ContentletControllerBasicTests extends AbstractContentletController
     @DisplayName("GET /{id} endpoint")
     class GetByIdEndpoint {
 
-        ContentletEntity savedContentlet = new ContentletEntity(UuidV7.generate());
+        ContentletEntity savedContentlet = new ContentletEntity(UuidV7.generate(), "SomeType", Map.of());
 
         @BeforeAll
         void beforeAll() {
@@ -353,7 +434,7 @@ public class ContentletControllerBasicTests extends AbstractContentletController
         class DeleteAContentlet {
 
             // Given
-            static ContentletEntity toDelete = new ContentletEntity(UuidV7.generate());
+            static ContentletEntity toDelete = new ContentletEntity(UuidV7.generate(), "SomeType", Map.of());
 
             static WebTestClient.ResponseSpec response;
 

--- a/src/test/java/com/contented/contented/contentlet/ContentletControllerFieldTests.java
+++ b/src/test/java/com/contented/contented/contentlet/ContentletControllerFieldTests.java
@@ -50,7 +50,7 @@ public class ContentletControllerFieldTests extends AbstractContentletController
 
             // Given a body with no id (ids are server-assigned)
             SomethingThatLooksLikeAContentlet toSave =
-                new SomethingThatLooksLikeAContentlet(null, "field1Value", 123);
+                new SomethingThatLooksLikeAContentlet(null, "SomeType", "field1Value", 123);
 
             UUID createdId;
 
@@ -89,7 +89,7 @@ public class ContentletControllerFieldTests extends AbstractContentletController
         class GivenAContentletWithFieldsWasSaved {
             // Given a body with no id (ids are server-assigned)
             SomethingThatLooksLikeAContentlet toSave =
-                new SomethingThatLooksLikeAContentlet(null, "field1Value", 123);
+                new SomethingThatLooksLikeAContentlet(null, "SomeType", "field1Value", 123);
 
             UUID createdId;
 
@@ -146,7 +146,7 @@ public class ContentletControllerFieldTests extends AbstractContentletController
         @DisplayName("given a contentlet with complex fields was saved")
         class GivenAContentletWithComplexFieldsWasSaved {
 
-            record ContentletWithComplexFields(String id, List<String> strings, List<ComplexField> stuff) {
+            record ContentletWithComplexFields(String id, String contentType, List<String> strings, List<ComplexField> stuff) {
             }
 
             record ComplexField(String field1, int field2) {
@@ -154,6 +154,7 @@ public class ContentletControllerFieldTests extends AbstractContentletController
 
             ContentletWithComplexFields toSave = new ContentletWithComplexFields(
                 null,
+                "SomeType",
                 List.of("string1", "string2"),
                 List.of(new ComplexField("field1Value", 123), new ComplexField("field2Value", 456))
             );
@@ -213,6 +214,6 @@ public class ContentletControllerFieldTests extends AbstractContentletController
 
     }
 
-    record SomethingThatLooksLikeAContentlet(String id, String field1, int field2) {
+    record SomethingThatLooksLikeAContentlet(String id, String contentType, String field1, int field2) {
     }
 }

--- a/src/test/java/com/contented/contented/contentlet/ContentletServiceIntegrationTests.java
+++ b/src/test/java/com/contented/contented/contentlet/ContentletServiceIntegrationTests.java
@@ -74,10 +74,9 @@ public class ContentletServiceIntegrationTests {
         class SavingContentletWithESTransformations {
 
             // contentType = "Blog" will match criteria for a transformation
-            ContentletEntity toSave = new ContentletEntity(null,
+            ContentletEntity toSave = new ContentletEntity(null, "Blog",
                 Map.ofEntries(
                     entry("language", "en"),
-                    entry("contentType", "Blog"),
                     entry("title", "Blog Title"),
                     entry("slug", "blog-slug")));
 

--- a/src/test/java/com/contented/contented/contentlet/ContentletServiceTest.java
+++ b/src/test/java/com/contented/contented/contentlet/ContentletServiceTest.java
@@ -24,6 +24,7 @@ import static com.contented.contented.contentlet.testutils.StubbingUtils.passthr
 import static com.contented.contented.contentlet.testutils.StubbingUtils.passthroughElasticSearchOperations;
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.*;
 
 @DisplayName("ContentletService")
@@ -46,7 +47,8 @@ public class ContentletServiceTest {
         ContentletRepository repository = Mockito.mock(ContentletRepository.class);
         ContentletService contentletService;
 
-        ContentletEntity toCreate = new ContentletEntity(null);
+        // A contentType that matches no transformer keeps this a pass-through save.
+        ContentletEntity toCreate = new ContentletEntity(null, "SomeType", Map.of());
         ContentletEntity created;
 
         @BeforeAll
@@ -83,10 +85,9 @@ public class ContentletServiceTest {
         ContentletRepository repository = Mockito.mock(ContentletRepository.class);
         ContentletService contentletService;
 
-        ContentletEntity toCreate = new ContentletEntity(null,
+        ContentletEntity toCreate = new ContentletEntity(null, "Blog",
             Map.ofEntries(
-                entry("language", "EN"),
-                entry("contentType", "Blog")));
+                entry("language", "EN")));
 
         @BeforeAll
         void beforeAll() {
@@ -125,15 +126,15 @@ public class ContentletServiceTest {
             ContentletService contentletService;
 
             UUID id = UuidV7.generate();
-            ContentletEntity toUpdate = new ContentletEntity(id);
+            ContentletEntity toUpdate = new ContentletEntity(id, "SomeType", Map.of());
             Optional<ContentletEntity> result;
 
             @BeforeAll
             void beforeAll() {
                 contentletService = newServiceWith(repository);
 
-                // Given
-                when(repository.existsById(id)).thenReturn(true);
+                // Given an existing contentlet with the same (immutable) contentType
+                when(repository.findById(id)).thenReturn(Optional.of(new ContentletEntity(id, "SomeType", Map.of())));
 
                 // When
                 result = contentletService.update(id, toUpdate);
@@ -167,11 +168,10 @@ public class ContentletServiceTest {
             void beforeAll() {
                 contentletService = newServiceWith(repository);
 
-                // Given
-                when(repository.existsById(id)).thenReturn(false);
+                // Given the repository has no contentlet for this id (findById returns empty by default)
 
                 // When
-                result = contentletService.update(id, new ContentletEntity(id));
+                result = contentletService.update(id, new ContentletEntity(id, "SomeType", Map.of()));
             }
 
             @Test
@@ -185,6 +185,70 @@ public class ContentletServiceTest {
             void should_not_save_anything() {
                 verify(repository, never()).save(any());
             }
+        }
+
+        @NestedPerClass
+        @DisplayName("when the contentType differs from the stored one")
+        class WhenContentTypeChanges {
+
+            ContentletRepository repository = Mockito.mock(ContentletRepository.class);
+            ContentletService contentletService;
+
+            UUID id = UuidV7.generate();
+            Throwable thrown;
+
+            @BeforeAll
+            void beforeAll() {
+                contentletService = newServiceWith(repository);
+
+                // Given a stored contentlet whose contentType is "Blog"
+                when(repository.findById(id)).thenReturn(Optional.of(new ContentletEntity(id, "Blog", Map.of())));
+
+                // When an update supplies a different contentType
+                thrown = catchThrowable(() -> contentletService.update(id, new ContentletEntity(id, "News", Map.of())));
+            }
+
+            @Test
+            @DisplayName("it should reject the change as invalid")
+            void should_reject_the_change() {
+                assertThat(thrown).isInstanceOf(InvalidContentletException.class);
+            }
+
+            @Test
+            @DisplayName("it should not save anything")
+            void should_not_save_anything() {
+                verify(repository, never()).save(any());
+            }
+        }
+    }
+
+    @NestedPerClass
+    @DisplayName("when the contentType is missing")
+    class WhenContentTypeMissing {
+
+        ContentletRepository repository = Mockito.mock(ContentletRepository.class);
+        ContentletService contentletService;
+
+        Throwable thrown;
+
+        @BeforeAll
+        void beforeAll() {
+            contentletService = newServiceWith(repository);
+
+            // When creating without a contentType
+            thrown = catchThrowable(() -> contentletService.create(new ContentletEntity(null, null, Map.of())));
+        }
+
+        @Test
+        @DisplayName("it should reject the create as invalid")
+        void should_reject_the_create() {
+            assertThat(thrown).isInstanceOf(InvalidContentletException.class);
+        }
+
+        @Test
+        @DisplayName("it should not save anything")
+        void should_not_save_anything() {
+            verify(repository, never()).save(any());
         }
     }
 }

--- a/src/test/java/com/contented/contented/contentlet/elasticsearch/ContentletIndexerTest.java
+++ b/src/test/java/com/contented/contented/contentlet/elasticsearch/ContentletIndexerTest.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import static com.contented.contented.contentlet.elasticsearch.transformation.StandardContentletTransformations.applyStandardTransformations;
 import static com.contented.contented.contentlet.testutils.StubbingUtils.passthroughElasticSearchOperations;
-import static com.contented.contented.contentlet.transformation.StandardDMSContentTransformer.CONTENT_TYPE_FIELD;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -52,9 +51,8 @@ class ContentletIndexerTest {
         @NestedPerClass
         class GivenContentletWhoseTransformerSpawnsMultipleEntities {
 
-            ContentletEntity contentletEntity = new ContentletEntity(UuidV7.generate(),
-                Map.of("identifier", "identifier1",
-                    CONTENT_TYPE_FIELD, "TestMultiEntityContentType"));
+            ContentletEntity contentletEntity = new ContentletEntity(UuidV7.generate(), "TestMultiEntityContentType",
+                Map.of("identifier", "identifier1"));
 
             @Test
             @DisplayName("it should pass each entity to the underlying ElasticsearchOperations#save to save them all")
@@ -97,9 +95,8 @@ class ContentletIndexerTest {
         @NestedPerClass
         class GivenContentletWithNoMatchingTransformer {
 
-            ContentletEntity contentletEntity = new ContentletEntity(UuidV7.generate(),
-                Map.of("identifier", "identifier1",
-                    CONTENT_TYPE_FIELD, "TypeWithNoTransformer"));
+            ContentletEntity contentletEntity = new ContentletEntity(UuidV7.generate(), "TypeWithNoTransformer",
+                Map.of("identifier", "identifier1"));
 
             @Test
             @DisplayName("it should return an empty list")
@@ -130,7 +127,7 @@ class ContentletIndexerTest {
 
         @Override
         public boolean test(ContentletEntity contentletEntity) {
-            return "TestMultiEntityContentType".equals(contentletEntity.getSchemalessData().get(CONTENT_TYPE_FIELD));
+            return "TestMultiEntityContentType".equals(contentletEntity.getContentType());
         }
     }
 }

--- a/src/test/java/com/contented/contented/contentlet/elasticsearch/transformation/BlogTransformerTest.java
+++ b/src/test/java/com/contented/contented/contentlet/elasticsearch/transformation/BlogTransformerTest.java
@@ -33,9 +33,8 @@ class BlogTransformerTest {
 
             ContentletEntity toTransform = new StandardDMSContentTransformer(clock)
                     .transform(
-                            new ContentletEntity(UuidV7.generate(),
+                            new ContentletEntity(UuidV7.generate(), "Blog",
                                     Map.ofEntries(
-                                            entry("contentType", "Blog"),
                                             entry("title", "Blog Title"),
                                             entry("body", "Blog Body"),
                                             entry("language", "en")

--- a/src/test/java/com/contented/contented/contentlet/transformation/StandardDMSContentTransformerTest.java
+++ b/src/test/java/com/contented/contented/contentlet/transformation/StandardDMSContentTransformerTest.java
@@ -29,10 +29,8 @@ class StandardDMSContentTransformerTest {
         @DisplayName("Given a contentletEntity with no id")
         class GivenContentletWithNoId {
 
-            ContentletEntity contentletEntity = new ContentletEntity(null,
-                Map.ofEntries(entry("language", "EN"),
-                    entry("contentType", "Blog")
-                )
+            ContentletEntity contentletEntity = new ContentletEntity(null, "Blog",
+                Map.ofEntries(entry("language", "EN"))
             );
 
             @Test
@@ -70,9 +68,8 @@ class StandardDMSContentTransformerTest {
         @DisplayName("Given a contentletEntity with an id")
         class GivenContentletWithId {
 
-            ContentletEntity toSave = new ContentletEntity(UuidV7.generate(), Map.ofEntries(
-                entry("language", "en"),
-                entry("contentType", "Blog")
+            ContentletEntity toSave = new ContentletEntity(UuidV7.generate(), "Blog", Map.ofEntries(
+                entry("language", "en")
             ));
 
             @Test
@@ -94,7 +91,7 @@ class StandardDMSContentTransformerTest {
         @Test
         @DisplayName("it should match a contentlet whose contentType is supported")
         void it_should_match_supported_content_type() {
-            var contentletEntity = new ContentletEntity(null, Map.of("contentType", "Blog"));
+            var contentletEntity = new ContentletEntity(null, "Blog", Map.of());
 
             assertThat(transformer.test(contentletEntity)).isTrue();
         }
@@ -102,7 +99,7 @@ class StandardDMSContentTransformerTest {
         @Test
         @DisplayName("it should not match a contentlet whose contentType is unsupported")
         void it_should_not_match_unsupported_content_type() {
-            var contentletEntity = new ContentletEntity(null, Map.of("contentType", "SomethingElse"));
+            var contentletEntity = new ContentletEntity(null, "SomethingElse", Map.of());
 
             assertThat(transformer.test(contentletEntity)).isFalse();
         }


### PR DESCRIPTION
contentType was a key inside the schemaless map. Make it a first-class field on ContentletEntity (its own content_type column) and ContentletDTO, validated in ContentletService:

- required: create/update with a blank contentType is rejected (400)
- immutable: update loads the current row and rejects a changed contentType (400); the stored casing is preserved

A declared field wins over @JsonAnySetter, so contentType never lands in the schemaless map on the JSON path; the (id, contentType, map) constructor keeps it explicit for programmatic callers. Entity construction now flows through a single base constructor that takes isNew as an explicit argument, with a @PersistenceCreator static factory for DB-loaded rows. Transformers and ES indexing read getContentType() instead of the map.

Liquibase 002 adds the column, backfills from data->>'contentType', strips it from the jsonb, and sets NOT NULL.